### PR TITLE
[DP-105] origin String → List로 변경

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/global/properties/CorsProperties.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/properties/CorsProperties.java
@@ -1,22 +1,23 @@
-package com.dreamypatisiel.devdevdev.web;
+package com.dreamypatisiel.devdevdev.global.properties;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-@ConfigurationProperties(prefix = "cors")
-@TestPropertySource("classpath:application-test.yml")
+@ConfigurationProperties("cors")
+@RequiredArgsConstructor
 public class CorsProperties {
     private List<String> origin = new ArrayList<>();
-
     public List<String> getOrigin() {
-        return origin;
+        return this.origin;
     }
-
+    public List<String> getUnmodifiableOrigins() {
+        return Collections.unmodifiableList(origin);
+    }
     public void setOrigin(List<String> origin) {
         this.origin = origin;
     }
-
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/config/CorsConfig.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/config/CorsConfig.java
@@ -16,11 +16,10 @@ public class CorsConfig {
 
 
     @Value("${cors.origin}")
-    public String origin;
+    public List<String> origins;
 
     @Bean
     protected CorsConfigurationSource apiCorsConfigurationSource() {
-        List<String> origins = List.of(origin);
 
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(origins);

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/config/CorsConfig.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/config/CorsConfig.java
@@ -1,25 +1,32 @@
 package com.dreamypatisiel.devdevdev.global.security.config;
 
-import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.PREFLIGHT_MAX_AGE;
-import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.WILDCARD_PATTERN;
-
-import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
+import com.dreamypatisiel.devdevdev.global.properties.CorsProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
+import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.PREFLIGHT_MAX_AGE;
+import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.WILDCARD_PATTERN;
+
 @Configuration
+@EnableConfigurationProperties(CorsProperties.class)
 public class CorsConfig {
 
-
-    @Value("${cors.origin}")
     public List<String> origins;
+
+    @Autowired
+    CorsProperties corsProperties;
 
     @Bean
     protected CorsConfigurationSource apiCorsConfigurationSource() {
+
+        origins = corsProperties.getUnmodifiableOrigins();
 
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(origins);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,7 +8,8 @@ domain:
     host: http://localhost:8080
 
 cors:
-  origin: http://localhost:3000
+  origin:
+    http://localhost:3000
 
 spring:
   config:

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/CorsProperties.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/CorsProperties.java
@@ -1,0 +1,22 @@
+package com.dreamypatisiel.devdevdev.web;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "cors")
+@TestPropertySource("classpath:application-test.yml")
+public class CorsProperties {
+    private List<String> origin = new ArrayList<>();
+
+    public List<String> getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(List<String> origin) {
+        this.origin = origin;
+    }
+
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/CorsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/CorsTest.java
@@ -1,12 +1,12 @@
 package com.dreamypatisiel.devdevdev.web;
 
-import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.PREFLIGHT_MAX_AGE;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -16,32 +16,49 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.PREFLIGHT_MAX_AGE;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@EnableConfigurationProperties(CorsProperties.class)
 public class CorsTest {
 
     @Autowired
     MockMvc mockMvc;
     String urlTemplate = "/devdevdev/api/v1/public";
+    static List<String> origins;
 
-    @Value("${cors.origin}")
-    String originUrl;
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("corsOriginProvider")
     @DisplayName("CORS 허용 테스트")
-    void corsAllowedTest() throws Exception {
+    void corsAllowedTest(String origin) throws Exception {
         // given // when // then
         mockMvc.perform(MockMvcRequestBuilders.options(urlTemplate)
-                        .header(HttpHeaders.ORIGIN, originUrl)
+                        .header(HttpHeaders.ORIGIN, origin)
                         .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.GET)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.header()
-                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, originUrl))
+                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
                 .andExpect(MockMvcResultMatchers.header()
                         .string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, HttpMethod.GET.name()))
                 .andExpect(MockMvcResultMatchers.header()
                         .string(HttpHeaders.ACCESS_CONTROL_MAX_AGE, String.valueOf(PREFLIGHT_MAX_AGE)));
     }
+
+    @BeforeAll
+    static void setup(@Autowired CorsProperties corsProperties) {
+        origins = corsProperties.getOrigin();
+    }
+
+    static Stream<Arguments> corsOriginProvider() {
+        return origins.stream().map(Arguments::of);
+    }
+
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/CorsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/CorsTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.web;
 
+import com.dreamypatisiel.devdevdev.global.properties.CorsProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,6 +33,10 @@ public class CorsTest {
     String urlTemplate = "/devdevdev/api/v1/public";
     static List<String> origins;
 
+    @BeforeAll
+    static void setup(@Autowired CorsProperties corsProperties) {
+        origins = corsProperties.getUnmodifiableOrigins();
+    }
 
     @ParameterizedTest
     @MethodSource("corsOriginProvider")
@@ -50,11 +55,6 @@ public class CorsTest {
                         .string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, HttpMethod.GET.name()))
                 .andExpect(MockMvcResultMatchers.header()
                         .string(HttpHeaders.ACCESS_CONTROL_MAX_AGE, String.valueOf(PREFLIGHT_MAX_AGE)));
-    }
-
-    @BeforeAll
-    static void setup(@Autowired CorsProperties corsProperties) {
-        origins = corsProperties.getOrigin();
     }
 
     static Stream<Arguments> corsOriginProvider() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,10 @@ domain:
     host: https://api.devdevdev.co.kr
 
 cors:
-  origin: http://localhost:3000
+  origin:
+    http://localhost:3000,
+    https://dev.devdevdev.co.kr
+
 
 spring:
   jpa:


### PR DESCRIPTION
- cors.origin 프로퍼티를 String-> List로 변경
- CorsTest 테스트코드에서도 origin list에 대해 모두 테스트할 수 있도록 변경
  - 프로퍼티 읽어올 수 있도록 @ConfigurationProperties 클래스 생성
  - CorsTest에서 해당 프로퍼티에 접근할 수 있도록 설정 및 @MethodSource, @ParameterizedTest 적용