### PR TITLE
[DP-140] Swagger servers url 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/global/config/SwaggerConfig.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 import java.util.Collections;
 
@@ -32,6 +33,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(apiInfo())
+                .addServersItem(new Server().url("/").description("server"))
                 .components(new Components().addSecuritySchemes("accessToken", accessToken))
                 .security(Collections.singletonList(securityRequirement));
     }


### PR DESCRIPTION
http 프로토콜을 사용하는 Generated Server가 아닌 Swagger 서버를 생성하도록 변경
참고(https://github.com/springdoc/springdoc-openapi/issues/726)