### PR TITLE
[DP-174] 요청시 id -> techArticleId 형식으로 명시적으로 변경

### DIFF
--- a/src/docs/asciidoc/api/pick/pick-modify.adoc
+++ b/src/docs/asciidoc/api/pick/pick-modify.adoc
@@ -1,5 +1,5 @@
 [[Pick-Modify]]
-== 픽픽픽 수정 API(PATCH: /devdevdev/api/v1/picks)
+== 픽픽픽 수정 API(PATCH: /devdevdev/api/v1/picks/{pickId})
 * 픽픽픽을 수정한다.
 * 회원만 픽픽픽 수정 할 수 있다.
 * 회원 본인이 작성한 픽픽픽만 수정할 수 있다.
@@ -10,6 +10,8 @@
 include::{snippets}/pick-modify/http-request.adoc[]
 ==== HTTP Request Header Fields
 include::{snippets}/pick-modify/request-headers.adoc[]
+==== HTTP Request Path Parameters Fields
+include::{snippets}/pick-modify/path-parameters.adoc[]
 ==== HTTP Request Fields
 include::{snippets}/pick-modify/request-fields.adoc[]
 

--- a/src/docs/asciidoc/api/tech-article/bookmark.adoc
+++ b/src/docs/asciidoc/api/tech-article/bookmark.adoc
@@ -1,5 +1,5 @@
 [[TechArticleBookmark]]
-== 기술블로그 북마크 API(POST: /devdevdev/api/v1/articles/{id}/bookmark)
+== 기술블로그 북마크 API(POST: /devdevdev/api/v1/articles/{techArticleId}/bookmark)
 * 회원은 기술블로그 북마크 여부를 생성/갱신할 수 있다.
 
 === 정상 요청/응답

--- a/src/docs/asciidoc/api/tech-article/detail.adoc
+++ b/src/docs/asciidoc/api/tech-article/detail.adoc
@@ -1,5 +1,5 @@
 [[TechArticleDetail]]
-== 기술블로그 상세 API(GET: /devdevdev/api/v1/articles/{id})
+== 기술블로그 상세 API(GET: /devdevdev/api/v1/articles/{techArticleId})
 * 기술블로그 상세 페이지를 조회한다.
 * 회원/익명 사용자에 따라 API 응답값이 상이하다.
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleController.java
@@ -42,24 +42,24 @@ public class TechArticleController {
     }
 
     @Operation(summary = "기술블로그 상세")
-    @GetMapping("/articles/{id}")
-    public ResponseEntity<BasicResponse<TechArticleResponse>> getTechArticle (@PathVariable Long id) {
+    @GetMapping("/articles/{techArticleId}")
+    public ResponseEntity<BasicResponse<TechArticleResponse>> getTechArticle (@PathVariable Long techArticleId) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        TechArticleResponse response = techArticleService.getTechArticle(id, authentication);
+        TechArticleResponse response = techArticleService.getTechArticle(techArticleId, authentication);
 
         return ResponseEntity.ok(BasicResponse.success(response));
     }
 
     @Operation(summary = "기술블로그 북마크")
-    @PostMapping("/articles/{id}/bookmark")
-    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark (@PathVariable Long id,
+    @PostMapping("/articles/{techArticleId}/bookmark")
+    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark (@PathVariable Long techArticleId,
                                                                            @RequestParam boolean status) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        BookmarkResponse response = techArticleService.updateBookmark(id, status, authentication);
+        BookmarkResponse response = techArticleService.updateBookmark(techArticleId, status, authentication);
 
         return ResponseEntity.ok(BasicResponse.success(response));
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickControllerDocsTest.java
@@ -1,50 +1,10 @@
 package com.dreamypatisiel.devdevdev.web.docs;
 
-import static com.dreamypatisiel.devdevdev.domain.service.pick.MemberPickService.FIRST_PICK_OPTION_IMAGE;
-import static com.dreamypatisiel.devdevdev.domain.service.pick.MemberPickService.SECOND_PICK_OPTION_IMAGE;
-import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
-import static com.dreamypatisiel.devdevdev.web.controller.request.PickOptionName.FIRST_PICK_OPTION;
-import static com.dreamypatisiel.devdevdev.web.controller.request.PickOptionName.SECOND_PICK_OPTION;
-import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.authenticationType;
-import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.pickOptionImageNameType;
-import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.pickSortType;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.JsonFieldType.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
-import com.dreamypatisiel.devdevdev.domain.entity.Member;
-import com.dreamypatisiel.devdevdev.domain.entity.Pick;
-import com.dreamypatisiel.devdevdev.domain.entity.PickOption;
-import com.dreamypatisiel.devdevdev.domain.entity.PickOptionImage;
-import com.dreamypatisiel.devdevdev.domain.entity.PickVote;
-import com.dreamypatisiel.devdevdev.domain.entity.Role;
-import com.dreamypatisiel.devdevdev.domain.entity.SocialType;
+import com.dreamypatisiel.devdevdev.domain.entity.*;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.PickOptionContents;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Title;
@@ -61,13 +21,6 @@ import com.dreamypatisiel.devdevdev.web.controller.request.ModifyPickOptionReque
 import com.dreamypatisiel.devdevdev.web.controller.request.ModifyPickRequest;
 import com.dreamypatisiel.devdevdev.web.controller.request.RegisterPickOptionRequest;
 import com.dreamypatisiel.devdevdev.web.controller.request.RegisterPickRequest;
-import com.dreamypatisiel.devdevdev.web.response.ResultType;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -78,13 +31,40 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.dreamypatisiel.devdevdev.domain.service.pick.MemberPickService.FIRST_PICK_OPTION_IMAGE;
+import static com.dreamypatisiel.devdevdev.domain.service.pick.MemberPickService.SECOND_PICK_OPTION_IMAGE;
+import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
+import static com.dreamypatisiel.devdevdev.web.controller.request.PickOptionName.FIRST_PICK_OPTION;
+import static com.dreamypatisiel.devdevdev.web.controller.request.PickOptionName.SECOND_PICK_OPTION;
+import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class PickControllerDocsTest extends SupportControllerDocsTest {
 
@@ -429,7 +409,7 @@ public class PickControllerDocsTest extends SupportControllerDocsTest {
     }
 
     @Test
-    @DisplayName("비회원은 픽픽픽 옵션에 대한 이미지를 삭제할 수 없다")
+    @DisplayName("비회원은 픽픽픽 옵션에 대한 이미지를 삭제할 수 없다.")
     void deleteImageAnonymousException() throws Exception {
         // given
         SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
@@ -758,6 +738,9 @@ public class PickControllerDocsTest extends SupportControllerDocsTest {
                 preprocessResponse(prettyPrint()),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER).description("Bearer 엑세스 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("pickId").description("픽픽픽 아이디")
                 ),
                 requestFields(
                         fieldWithPath("pickTitle").type(STRING).description("픽픽픽 타이틀"),

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -275,7 +275,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{id}", id)
+        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{techArticleId}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -290,7 +290,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         headerWithName(AUTHORIZATION_HEADER).optional().description("Bearer 엑세스 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("id").description("기술블로그 아이디")
+                        parameterWithName("techArticleId").description("기술블로그 아이디")
                 ),
                 responseFields(
                         fieldWithPath("resultType").type(JsonFieldType.STRING).description("응답 결과"),
@@ -329,7 +329,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         member.updateRefreshToken(refreshToken);
 
         // when // then
-        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{id}", id)
+        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{techArticleId}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -360,7 +360,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         Long id = savedTechArticle.getId()+1;
 
         // when // then
-        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{id}", id)
+        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{techArticleId}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -387,7 +387,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         Long id = savedTechArticle.getId();
 
         // when // then
-        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{id}", id)
+        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{techArticleId}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -414,7 +414,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         Long id = savedTechArticle.getId();
 
         // when // then
-        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{id}", id)
+        ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles/{techArticleId}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -443,7 +443,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        ResultActions actions = mockMvc.perform(post("/devdevdev/api/v1/articles/{id}/bookmark", id)
+        ResultActions actions = mockMvc.perform(post("/devdevdev/api/v1/articles/{techArticleId}/bookmark", id)
                         .queryParam("status", String.valueOf(true))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
@@ -461,7 +461,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         parameterWithName("status").description("북마크 상태")
                 ),
                 pathParameters(
-                        parameterWithName("id").description("기술블로그 아이디")
+                        parameterWithName("techArticleId").description("기술블로그 아이디")
                 ),
                 responseFields(
                         fieldWithPath("resultType").type(JsonFieldType.STRING).description("응답 결과"),


### PR DESCRIPTION
-  request path id -> techArticleId 형식으로 명시적으로 변경
- 픽피픽 수정 docs에 path param 추가 및 patch import 변경(MockMvcRequestBuilders → RestDocumentationRequestBuilders )
- 그외 오타 수정