### PR TITLE
[PRD-183] API Response 변경

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickService.java
@@ -77,6 +77,7 @@ public class GuestPickService implements PickService {
                 .viewTotalCount(pick.getViewTotalCount())
                 .popularScore(pick.getPopularScore())
                 .pickOptions(mapToPickOptionsResponse(pick))
+                .isVoted(false)
                 .build();
     }
 
@@ -91,6 +92,7 @@ public class GuestPickService implements PickService {
                 .id(pickOption.getId())
                 .title(pickOption.getTitle())
                 .percent(PickOption.calculatePercentBy(pick, pickOption))
+                .isPicked(false)
                 .build();
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/CompanyResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/CompanyResponse.java
@@ -1,13 +1,11 @@
 package com.dreamypatisiel.devdevdev.domain.service.response;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Company;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Data
-@JsonInclude(JsonInclude.Include.NON_NULL) // null 인 필드는 제외
 @RequiredArgsConstructor
 public class CompanyResponse {
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickOptionResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickOptionResponse.java
@@ -1,14 +1,11 @@
 package com.dreamypatisiel.devdevdev.domain.service.response;
 
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Title;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
-@JsonInclude(Include.NON_NULL) // null 인 필드는 제외
 public class PickOptionResponse {
     private final Long id;
     private final String title;

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickUploadImageResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickUploadImageResponse.java
@@ -1,14 +1,11 @@
 package com.dreamypatisiel.devdevdev.domain.service.response;
 
 import com.dreamypatisiel.devdevdev.domain.entity.PickOptionImage;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
-@JsonInclude(Include.NON_NULL)
 public class PickUploadImageResponse {
     private List<PickOptionImagesResponse> pickOptionImages;
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PicksResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PicksResponse.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@JsonInclude(Include.NON_NULL) // null 인 필드는 제외
 public class PicksResponse {
     private final Long id;
     private final String title;

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleResponse.java
@@ -2,15 +2,12 @@ package com.dreamypatisiel.devdevdev.domain.service.response;
 
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDate;
-
 @Data
-@JsonInclude(JsonInclude.Include.NON_NULL) // null 인 필드는 제외
 @RequiredArgsConstructor
 public class TechArticleResponse {
 
@@ -65,6 +62,7 @@ public class TechArticleResponse {
                 .regDate(elasticTechArticle.getRegDate())
                 .author(elasticTechArticle.getAuthor())
                 .contents(truncateString(elasticTechArticle.getContents(), CONTENTS_MAX_LENGTH))
+                .isBookmarked(false)
                 .build();
     }
 
@@ -100,6 +98,7 @@ public class TechArticleResponse {
                 .company(companyResponse)
                 .regDate(elasticTechArticle.getRegDate())
                 .author(elasticTechArticle.getAuthor())
+                .isBookmarked(false)
                 .score(getValidScore(score))
                 .build();
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
@@ -86,7 +86,7 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
     }
 
     @Test
-    @DisplayName("익명 사용자가 기술블로그 상세를 조회한다. 이때 북마크 여부는 응답에 포함되지 않는다.")
+    @DisplayName("익명 사용자가 기술블로그 상세를 조회한다. 이때 북마크 값은 false 이다.")
     void getTechArticle() {
         // given
         Long id = FIRST_TECH_ARTICLE_ID;
@@ -104,7 +104,7 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
                 .isInstanceOf(TechArticleResponse.class)
                 .satisfies(article -> {
                     assertThat(article.getId()).isNotNull();
-                    assertThat(article.getIsBookmarked()).isNull();
+                    assertThat(article.getIsBookmarked()).isFalse();
                 });
     }
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -312,7 +312,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         fieldWithPath("data.recommendTotalCount").type(JsonFieldType.NUMBER).description("기술블로그 추천수"),
                         fieldWithPath("data.commentTotalCount").type(JsonFieldType.NUMBER).description("기술블로그 댓글수"),
                         fieldWithPath("data.popularScore").type(JsonFieldType.NUMBER).description("기술블로그 인기점수"),
-                        fieldWithPath("data.isBookmarked").attributes(authenticationType()).type(JsonFieldType.BOOLEAN).description("회원의 북마크 여부(익명 사용자는 필드가 없다)")
+                        fieldWithPath("data.isBookmarked").attributes(authenticationType()).type(JsonFieldType.BOOLEAN).description("회원의 북마크 여부(익명 사용자는 필드가 없다)"),
+                        fieldWithPath("data.score").attributes(authenticationType()).type(JsonFieldType.NULL).description("기술블로그 검색 점수(정확도)")
                 )
         ));
     }


### PR DESCRIPTION
# API Response 변경
* null 응답 필드도 전달하도록 변경

# API Response 컨밴션
* boolean에 null은 없다! true | false
* 복수형 빈 값은 빈 배열로!!
* Null Object Pattern
* object 만 null 허용
* 의미 있는 null 값이 있는 경우라면 Enum 으로 대체