### PR TITLE
[DP-187] 기술블로그 메인 API - 회사 필터 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
@@ -14,6 +14,7 @@ import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.service.ElasticTechArticleService;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -99,6 +100,12 @@ public class GuestTechArticleService extends TechArticleCommonService implements
 
     private List<TechArticleMainResponse> mapToTechArticlesResponse(
             List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
+
+        // 조회 결과가 없을 경우 빈 리스트 응답
+        if (elasticTechArticlesResponse.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         List<TechArticle> findTechArticles = getTechArticlesByElasticIdsIn(elasticTechArticlesResponse);
         Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(
                 elasticTechArticlesResponse);

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
@@ -17,6 +17,9 @@ import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.service.ElasticTechArticleService;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,10 +28,6 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -57,9 +56,10 @@ public class MemberTechArticleService extends TechArticleCommonService implement
     @Override
     public Slice<TechArticleMainResponse> getTechArticles(Pageable pageable, String elasticId,
                                                           TechArticleSort techArticleSort, String keyword,
-                                                          Float score, Authentication authentication) {
+                                                          Long companyId, Float score, Authentication authentication) {
         // 기술블로그 조회
-        SearchHits<ElasticTechArticle> searchHits = elasticTechArticleService.getTechArticles(pageable, elasticId, techArticleSort, keyword, score);
+        SearchHits<ElasticTechArticle> searchHits = elasticTechArticleService.getTechArticles(pageable, elasticId,
+                techArticleSort, keyword, companyId, score);
 
         // 회원 조회
         Member member = memberProvider.getMemberByAuthentication(authentication);
@@ -86,7 +86,8 @@ public class MemberTechArticleService extends TechArticleCommonService implement
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         // 데이터 가공
-        return TechArticleDetailResponse.of(elasticTechArticle, techArticle, companyResponse, isBookmarkedByMember(techArticle, member));
+        return TechArticleDetailResponse.of(elasticTechArticle, techArticle, companyResponse,
+                isBookmarkedByMember(techArticle, member));
     }
 
     @Override
@@ -112,12 +113,15 @@ public class MemberTechArticleService extends TechArticleCommonService implement
     }
 
     @Override
-    public Slice<TechArticleMainResponse> getBookmarkedTechArticles(Pageable pageable, Long techArticleId, BookmarkSort bookmarkSort, Authentication authentication) {
+    public Slice<TechArticleMainResponse> getBookmarkedTechArticles(Pageable pageable, Long techArticleId,
+                                                                    BookmarkSort bookmarkSort,
+                                                                    Authentication authentication) {
         // 회원 조회
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         // 북마크 기술블로그 조회(rds, elasticsearch)
-        Slice<TechArticle> techArticleSlices = findBookmarkedTechArticles(pageable, techArticleId, bookmarkSort, member);
+        Slice<TechArticle> techArticleSlices = findBookmarkedTechArticles(pageable, techArticleId, bookmarkSort,
+                member);
         List<TechArticle> techArticles = techArticleSlices.getContent();
 
         // 데이터 가공
@@ -126,40 +130,51 @@ public class MemberTechArticleService extends TechArticleCommonService implement
         return new SliceImpl<>(techArticleMainRespons, pageable, techArticleSlices.hasNext());
     }
 
-    private List<TechArticleMainResponse> getTechArticlesResponse(SearchHits<ElasticTechArticle> searchHits, Member member) {
-        List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse = mapToElasticTechArticlesResponse(searchHits);
+    private List<TechArticleMainResponse> getTechArticlesResponse(SearchHits<ElasticTechArticle> searchHits,
+                                                                  Member member) {
+        List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse = mapToElasticTechArticlesResponse(
+                searchHits);
         return mapToTechArticlesResponse(elasticTechArticlesResponse, member);
     }
 
-    private List<TechArticleMainResponse> mapToTechArticlesResponse(List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse, Member member) {
+    private List<TechArticleMainResponse> mapToTechArticlesResponse(
+            List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse, Member member) {
         List<TechArticle> findTechArticles = getTechArticlesByElasticIdsIn(elasticTechArticlesResponse);
-        Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(elasticTechArticlesResponse);
+        Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(
+                elasticTechArticlesResponse);
 
         return findTechArticles.stream()
                 .map(techArticle -> {
-                    ElasticResponse<ElasticTechArticle> elasticResponse = elasticsResponseMap.get(techArticle.getElasticId());
+                    ElasticResponse<ElasticTechArticle> elasticResponse = elasticsResponseMap.get(
+                            techArticle.getElasticId());
                     CompanyResponse companyResponse = createCompanyResponse(techArticle);
-                    return TechArticleMainResponse.of(elasticResponse.content(), techArticle, companyResponse, elasticResponse.score(), isBookmarkedByMember(techArticle, member));
+                    return TechArticleMainResponse.of(elasticResponse.content(), techArticle, companyResponse,
+                            elasticResponse.score(), isBookmarkedByMember(techArticle, member));
                 })
                 .toList();
     }
 
     private List<TechArticleMainResponse> mapToTechArticlesResponse(List<TechArticle> techArticles) {
         List<ElasticTechArticle> elasticTechArticles = findElasticTechArticlesByElasticIdsIn(techArticles);
-        List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse = mapToElasticTechArticlesResponse(elasticTechArticles);
-        Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(elasticTechArticlesResponse);
-        
+        List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse = mapToElasticTechArticlesResponse(
+                elasticTechArticles);
+        Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(
+                elasticTechArticlesResponse);
+
         return techArticles.stream()
                 .map(techArticle -> {
-                    ElasticResponse<ElasticTechArticle> elasticResponse = elasticsResponseMap.get(techArticle.getElasticId());
+                    ElasticResponse<ElasticTechArticle> elasticResponse = elasticsResponseMap.get(
+                            techArticle.getElasticId());
                     CompanyResponse companyResponse = createCompanyResponse(techArticle);
-                    return TechArticleMainResponse.of(elasticResponse.content(), techArticle, companyResponse, elasticResponse.score(), true);
+                    return TechArticleMainResponse.of(elasticResponse.content(), techArticle, companyResponse,
+                            elasticResponse.score(), true);
                 })
                 .toList();
     }
 
     private boolean isBookmarkedByMember(TechArticle techArticle, Member member) {
-        boolean isBookmarked = bookmarkRepository.findByTechArticleAndMember(techArticle, member).map(Bookmark::isBookmarked).orElse(false);
+        boolean isBookmarked = bookmarkRepository.findByTechArticleAndMember(techArticle, member)
+                .map(Bookmark::isBookmarked).orElse(false);
         return isBookmarked;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
@@ -17,6 +17,7 @@ import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.service.ElasticTechArticleService;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,6 +140,12 @@ public class MemberTechArticleService extends TechArticleCommonService implement
 
     private List<TechArticleMainResponse> mapToTechArticlesResponse(
             List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse, Member member) {
+
+        // 조회 결과가 없을 경우 빈 리스트 응답
+        if (elasticTechArticlesResponse.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         List<TechArticle> findTechArticles = getTechArticlesByElasticIdsIn(elasticTechArticlesResponse);
         Map<String, ElasticResponse<ElasticTechArticle>> elasticsResponseMap = getElasticResponseMap(
                 elasticTechArticlesResponse);

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleCommonService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleCommonService.java
@@ -1,5 +1,9 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_TECH_ARTICLE_MESSAGE;
+
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
@@ -12,6 +16,12 @@ import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
 import com.dreamypatisiel.devdevdev.exception.TechArticleException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -19,14 +29,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.*;
 
 @Component
 @RequiredArgsConstructor
@@ -39,7 +41,7 @@ class TechArticleCommonService {
     protected ElasticTechArticle findElasticTechArticle(TechArticle techArticle) {
         String elasticId = techArticle.getElasticId();
 
-        if(elasticId == null) {
+        if (elasticId == null) {
             throw new TechArticleException(NOT_FOUND_ELASTIC_ID_MESSAGE);
         }
 
@@ -52,13 +54,15 @@ class TechArticleCommonService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_TECH_ARTICLE_MESSAGE));
     }
 
-    protected static List<ElasticResponse<ElasticTechArticle>> mapToElasticTechArticlesResponse(SearchHits<ElasticTechArticle> searchHits) {
+    protected static List<ElasticResponse<ElasticTechArticle>> mapToElasticTechArticlesResponse(
+            SearchHits<ElasticTechArticle> searchHits) {
         return searchHits.stream()
                 .map(searchHit -> new ElasticResponse<>(searchHit.getContent(), searchHit.getScore()))
                 .toList();
     }
 
-    protected static List<ElasticResponse<ElasticTechArticle>> mapToElasticTechArticlesResponse(List<ElasticTechArticle> elasticTechArticles) {
+    protected static List<ElasticResponse<ElasticTechArticle>> mapToElasticTechArticlesResponse(
+            List<ElasticTechArticle> elasticTechArticles) {
         return elasticTechArticles.stream()
                 .map(elasticTechArticle -> new ElasticResponse<>(elasticTechArticle, null))
                 .toList();
@@ -70,17 +74,25 @@ class TechArticleCommonService {
                 .toList();
     }
 
-    protected List<TechArticle> getTechArticlesByElasticIdsIn(List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
+    protected List<TechArticle> getTechArticlesByElasticIdsIn(
+            List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
         List<String> elasticIds = getElasticIds(elasticTechArticlesResponse);
+
+        if (elasticIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        
         return techArticleRepository.findAllByElasticIdIn(elasticIds);
     }
 
-    protected static Map<String, ElasticResponse<ElasticTechArticle>> getElasticResponseMap(List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
+    protected static Map<String, ElasticResponse<ElasticTechArticle>> getElasticResponseMap(
+            List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
         return elasticTechArticlesResponse.stream()
                 .collect(Collectors.toMap(el -> el.content().getId(), Function.identity()));
     }
 
-    protected ElasticSlice<TechArticleMainResponse> createElasticSlice(Pageable pageable, SearchHits<ElasticTechArticle> searchHits,
+    protected ElasticSlice<TechArticleMainResponse> createElasticSlice(Pageable pageable,
+                                                                       SearchHits<ElasticTechArticle> searchHits,
                                                                        List<TechArticleMainResponse> techArticlesResponse) {
         long totalHits = searchHits.getTotalHits();
         boolean hasNext = hasNextPage(pageable, searchHits);
@@ -97,7 +109,8 @@ class TechArticleCommonService {
         return searchHits.getSearchHits().size() >= pageable.getPageSize();
     }
 
-    protected Slice<TechArticle> findBookmarkedTechArticles(Pageable pageable, Long techArticleId, BookmarkSort bookmarkSort, Member member) {
+    protected Slice<TechArticle> findBookmarkedTechArticles(Pageable pageable, Long techArticleId,
+                                                            BookmarkSort bookmarkSort, Member member) {
         return techArticleRepository.findBookmarkedByCursor(pageable, techArticleId, bookmarkSort, member);
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleCommonService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleCommonService.java
@@ -78,10 +78,11 @@ class TechArticleCommonService {
             List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
         List<String> elasticIds = getElasticIds(elasticTechArticlesResponse);
 
+        // 추출한 elasticId가 없다면 빈 리스트 응답
         if (elasticIds.isEmpty()) {
             return Collections.emptyList();
         }
-        
+
         return techArticleRepository.findAllByElasticIdIn(elasticIds);
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleService.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Service;
 @Service
 public interface TechArticleService {
     Slice<TechArticleMainResponse> getTechArticles(Pageable pageable, String elasticId, TechArticleSort techArticleSort,
-                                                   String keyword, Float score, Authentication authentication);
+                                                   String keyword, Long companyId, Float score,
+                                                   Authentication authentication);
 
     TechArticleDetailResponse getTechArticle(Long id, Authentication authentication);
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/constant/ElasticsearchConstant.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/constant/ElasticsearchConstant.java
@@ -2,4 +2,5 @@ package com.dreamypatisiel.devdevdev.elastic.constant;
 
 public class ElasticsearchConstant {
     public static final String _ID = "_id";
+    public static final String _COMPANY_ID = "companyId";
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/document/ElasticTechArticle.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/document/ElasticTechArticle.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.elastic.domain.document;
 
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
@@ -7,10 +8,8 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import java.time.LocalDate;
-
 @Getter
-@Document(indexName = "articles"+"#{@elasticsearchIndexConfigService.getIndexName()}")
+@Document(indexName = "articles" + "#{@elasticsearchIndexConfigService.getIndexName()}")
 public class ElasticTechArticle {
     @Id
     private String id;
@@ -56,8 +55,9 @@ public class ElasticTechArticle {
 
     @Builder
     public ElasticTechArticle(String id, String title, LocalDate regDate, String contents, String techArticleUrl,
-                              String description, String thumbnailUrl, String author, String company,
-                              Long viewTotalCount, Long recommendTotalCount, Long commentTotalCount, Long popularScore) {
+                              String description, String thumbnailUrl, String author, Long companyId, String company,
+                              Long viewTotalCount, Long recommendTotalCount, Long commentTotalCount,
+                              Long popularScore) {
         this.id = id;
         this.title = title;
         this.regDate = regDate;
@@ -66,29 +66,11 @@ public class ElasticTechArticle {
         this.description = description;
         this.thumbnailUrl = thumbnailUrl;
         this.author = author;
+        this.companyId = companyId;
         this.company = company;
         this.viewTotalCount = viewTotalCount;
         this.recommendTotalCount = recommendTotalCount;
         this.commentTotalCount = commentTotalCount;
         this.popularScore = popularScore;
-    }
-
-    public static ElasticTechArticle of(String title, LocalDate regDate, String contents, String techArticleUrl,
-                                        String description, String thumbnailUrl, String author, String company,
-                                        Long viewTotalCount, Long recommendTotalCount, Long commentTotalCount, Long popularScore) {
-        return ElasticTechArticle.builder()
-                .title(title)
-                .regDate(regDate)
-                .contents(contents)
-                .techArticleUrl(techArticleUrl)
-                .description(description)
-                .thumbnailUrl(thumbnailUrl)
-                .author(author)
-                .company(company)
-                .viewTotalCount(viewTotalCount)
-                .recommendTotalCount(recommendTotalCount)
-                .commentTotalCount(commentTotalCount)
-                .popularScore(popularScore)
-                .build();
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
@@ -3,6 +3,7 @@ package com.dreamypatisiel.devdevdev.elastic.domain.service;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.INVALID_ELASTIC_METHODS_CALL_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstant._COMPANY_ID;
 import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstant._ID;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
@@ -107,7 +108,7 @@ public class ElasticTechArticleService {
         if (ObjectUtils.isEmpty(companyId)) {
             return;
         }
-        queryBuilder.withFilter(QueryBuilders.termQuery("companyId", companyId));
+        queryBuilder.withFilter(QueryBuilders.termQuery(_COMPANY_ID, companyId));
     }
 
     private FieldSortBuilder getPrimarySortCondition(String fieldName) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
@@ -1,10 +1,17 @@
 package com.dreamypatisiel.devdevdev.elastic.domain.service;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.INVALID_ELASTIC_METHODS_CALL_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstant._ID;
+
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.exception.ElasticTechArticleException;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
@@ -21,12 +28,6 @@ import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.*;
-import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstant._ID;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,26 +37,32 @@ public class ElasticTechArticleService {
     private final ElasticTechArticleRepository elasticTechArticleRepository;
 
     public SearchHits<ElasticTechArticle> getTechArticles(Pageable pageable, String elasticId,
-                                                          TechArticleSort techArticleSort, String keyword, Float score) {
-        if(ObjectUtils.isEmpty(keyword)) {
-            return findTechArticles(pageable, elasticId, techArticleSort);
+                                                          TechArticleSort techArticleSort, String keyword,
+                                                          Long companyId, Float score) {
+        if (ObjectUtils.isEmpty(keyword)) {
+            return findTechArticles(pageable, elasticId, techArticleSort, companyId);
         }
 
-        return searchTechArticles(pageable, elasticId, techArticleSort, keyword, score);
+        return searchTechArticles(pageable, elasticId, techArticleSort, keyword, companyId, score);
     }
 
-    private SearchHits<ElasticTechArticle> findTechArticles(Pageable pageable, String elasticId, TechArticleSort techArticleSort) {
+    private SearchHits<ElasticTechArticle> findTechArticles(Pageable pageable, String elasticId,
+                                                            TechArticleSort techArticleSort, Long companyId) {
         // 정렬 기준 검증
         techArticleSort = getValidSort(techArticleSort);
 
         // 쿼리 생성
-        NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+        NativeSearchQueryBuilder queryBuilder = new NativeSearchQueryBuilder()
                 .withSearchType(SearchType.QUERY_THEN_FETCH)
                 .withPageable(pageable)
                 // 정렬 조건 설정
                 .withSort(getSortCondition(techArticleSort))
-                .withSort(getPrimarySortCondition(_ID))
-                .build();
+                .withSort(getPrimarySortCondition(_ID));
+
+        // 회사 필터 설정
+        setFilterWithCompanyId(companyId, queryBuilder);
+
+        NativeSearchQuery searchQuery = queryBuilder.build();
 
         // searchAfter 설정
         setSearchAfterCondition(elasticId, techArticleSort, searchQuery);
@@ -64,9 +71,11 @@ public class ElasticTechArticleService {
     }
 
     private SearchHits<ElasticTechArticle> searchTechArticles(Pageable pageable, String elasticId,
-                                                              TechArticleSort techArticleSort, String keyword, Float score) {
+                                                              TechArticleSort techArticleSort, String keyword,
+                                                              Long companyId, Float score) {
+
         // 검색어 유무 확인
-        if(ObjectUtils.isEmpty(keyword)) {
+        if (ObjectUtils.isEmpty(keyword)) {
             throw new ElasticTechArticleException(INVALID_ELASTIC_METHODS_CALL_MESSAGE);
         }
 
@@ -74,20 +83,31 @@ public class ElasticTechArticleService {
         techArticleSort = getValidSortWhenSearch(techArticleSort);
 
         // 쿼리 생성
-        NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+        NativeSearchQueryBuilder queryBuilder = new NativeSearchQueryBuilder()
                 .withSearchType(SearchType.QUERY_THEN_FETCH)
                 .withPageable(pageable)
                 // 쿼리스트링
                 .withQuery(QueryBuilders.queryStringQuery(keyword))
                 // 정렬 조건 설정
                 .withSort(getSortCondition(techArticleSort))
-                .withSort(getPrimarySortCondition(_ID))
-                .build();
+                .withSort(getPrimarySortCondition(_ID));
+
+        // 회사 필터 설정
+        setFilterWithCompanyId(companyId, queryBuilder);
+
+        NativeSearchQuery searchQuery = queryBuilder.build();
 
         // searchAfter 설정
         setSearchAfterConditionWhenSearch(elasticId, score, techArticleSort, searchQuery);
 
         return elasticsearchOperations.search(searchQuery, ElasticTechArticle.class);
+    }
+
+    private static void setFilterWithCompanyId(Long companyId, NativeSearchQueryBuilder queryBuilder) {
+        if (ObjectUtils.isEmpty(companyId)) {
+            return;
+        }
+        queryBuilder.withFilter(QueryBuilders.termQuery("companyId", companyId));
     }
 
     private FieldSortBuilder getPrimarySortCondition(String fieldName) {
@@ -110,7 +130,7 @@ public class ElasticTechArticleService {
 
     private void setSearchAfterCondition(String elasticId, TechArticleSort techArticleSort,
                                          NativeSearchQuery searchQuery) {
-        if(ObjectUtils.isEmpty(elasticId)) {
+        if (ObjectUtils.isEmpty(elasticId)) {
             return;
         }
 
@@ -122,7 +142,7 @@ public class ElasticTechArticleService {
 
     private void setSearchAfterConditionWhenSearch(String elasticId, Float score, TechArticleSort techArticleSort,
                                                    NativeSearchQuery searchQuery) {
-        if(ObjectUtils.isEmpty(elasticId)) {
+        if (ObjectUtils.isEmpty(elasticId)) {
             return;
         }
 
@@ -136,14 +156,15 @@ public class ElasticTechArticleService {
         return List.of(techArticleSort.getSearchAfterCondition(elasticTechArticle), elasticTechArticle.getId());
     }
 
-    private List<Object> getSearchAfterWhenSearch(ElasticTechArticle elasticTechArticle, TechArticleSort techArticleSort,
+    private List<Object> getSearchAfterWhenSearch(ElasticTechArticle elasticTechArticle,
+                                                  TechArticleSort techArticleSort,
                                                   Float score) {
         // 정확도순 정렬이 아닌 경우
-        if(!TechArticleSort.HIGHEST_SCORE.equals(techArticleSort)) {
+        if (!TechArticleSort.HIGHEST_SCORE.equals(techArticleSort)) {
             return getSearchAfter(elasticTechArticle, techArticleSort);
         }
 
-        if(ObjectUtils.isEmpty(score)) {
+        if (ObjectUtils.isEmpty(score)) {
             throw new ElasticTechArticleException(NOT_FOUND_CURSOR_SCORE_MESSAGE);
         }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleController.java
@@ -16,7 +16,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "기술블로그 API", description = "기술블로그 메인, 상세 API")
 @RestController
@@ -28,23 +33,25 @@ public class TechArticleController {
 
     @Operation(summary = "기술블로그 메인 조회 및 검색")
     @GetMapping("/articles")
-    public ResponseEntity<BasicResponse<Slice<TechArticleMainResponse>>> getTechArticles (
+    public ResponseEntity<BasicResponse<Slice<TechArticleMainResponse>>> getTechArticles(
             @PageableDefault Pageable pageable,
             @RequestParam(required = false) TechArticleSort techArticleSort,
             @RequestParam(required = false) String elasticId,
             @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long companyId,
             @RequestParam(required = false) Float score) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        Slice<TechArticleMainResponse> response = techArticleService.getTechArticles(pageable, elasticId, techArticleSort, keyword, score, authentication);
+        Slice<TechArticleMainResponse> response = techArticleService.getTechArticles(pageable, elasticId,
+                techArticleSort, keyword, companyId, score, authentication);
 
         return ResponseEntity.ok(BasicResponse.success(response));
     }
 
     @Operation(summary = "기술블로그 상세")
     @GetMapping("/articles/{techArticleId}")
-    public ResponseEntity<BasicResponse<TechArticleDetailResponse>> getTechArticle (@PathVariable Long techArticleId) {
+    public ResponseEntity<BasicResponse<TechArticleDetailResponse>> getTechArticle(@PathVariable Long techArticleId) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
@@ -55,8 +62,8 @@ public class TechArticleController {
 
     @Operation(summary = "기술블로그 북마크")
     @PostMapping("/articles/{techArticleId}/bookmark")
-    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark (@PathVariable Long techArticleId,
-                                                                           @RequestParam boolean status) {
+    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark(@PathVariable Long techArticleId,
+                                                                          @RequestParam boolean status) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
@@ -1,10 +1,18 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle;
 
-import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
-import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.service.pick.GuestPickService.INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.service.response.TechArticleDetailResponse;
 import com.dreamypatisiel.devdevdev.domain.service.response.TechArticleMainResponse;
@@ -26,12 +34,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.*;
-import static com.dreamypatisiel.devdevdev.domain.service.pick.GuestPickService.INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 
 class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
 
@@ -61,7 +63,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         SecurityContextHolder.setContext(securityContext);
 
         // when
-        Slice<TechArticleMainResponse> techArticles = guestTechArticleService.getTechArticles(pageable, null, null, null, null, authentication);
+        Slice<TechArticleMainResponse> techArticles = guestTechArticleService.getTechArticles(pageable, null, null,
+                null, null, null, authentication);
 
         // then
         assertThat(techArticles)
@@ -81,7 +84,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when // then
-        assertThatThrownBy(() -> guestTechArticleService.getTechArticles(pageable, null, null, null, null, authentication))
+        assertThatThrownBy(
+                () -> guestTechArticleService.getTechArticles(pageable, null, null, null, null, null, authentication))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(AuthenticationMemberUtils.INVALID_METHODS_CALL_MESSAGE);
     }
@@ -97,7 +101,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         SecurityContextHolder.setContext(securityContext);
 
         // when
-        TechArticleDetailResponse techArticleDetailResponse = guestTechArticleService.getTechArticle(id, authentication);
+        TechArticleDetailResponse techArticleDetailResponse = guestTechArticleService.getTechArticle(id,
+                authentication);
 
         // then
         assertThat(techArticleDetailResponse)
@@ -121,13 +126,14 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         SecurityContextHolder.setContext(securityContext);
 
         // when
-        TechArticleDetailResponse techArticleDetailResponse = guestTechArticleService.getTechArticle(id, authentication);
+        TechArticleDetailResponse techArticleDetailResponse = guestTechArticleService.getTechArticle(id,
+                authentication);
 
         // then
         assertThat(techArticleDetailResponse)
                 .satisfies(article -> {
-                    assertThat(article.getViewTotalCount()==prevViewTotalCount+1);
-                    assertThat(article.getPopularScore()==prevPopularScore+2);
+                    assertThat(article.getViewTotalCount() == prevViewTotalCount + 1);
+                    assertThat(article.getPopularScore() == prevPopularScore + 2);
                 });
     }
 
@@ -153,10 +159,11 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("익명 사용자가 기술블로그 상세를 조회할 때 기술블로그가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundTechArticleException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), null, null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
-        Long id = savedTechArticle.getId()+1;
+        Long id = savedTechArticle.getId() + 1;
 
         when(authentication.getPrincipal()).thenReturn("anonymousUser");
         when(securityContext.getAuthentication()).thenReturn(authentication);
@@ -172,7 +179,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("익명 사용자가 기술블로그 상세를 조회할 때 엘라스틱ID가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundElasticIdException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), null, null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
         Long id = savedTechArticle.getId();
@@ -191,7 +199,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("익명 사용자가 기술블로그 상세를 조회할 때 엘라스틱 기술블로그가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundElasticTechArticleException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), "elasticId", null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
         Long id = savedTechArticle.getId();
@@ -236,7 +245,8 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when // then
-        assertThatThrownBy(() -> guestTechArticleService.getBookmarkedTechArticles(pageable, null, null, authentication))
+        assertThatThrownBy(
+                () -> guestTechArticleService.getBookmarkedTechArticles(pageable, null, null, authentication))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage(INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
@@ -1,6 +1,14 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle;
 
-import com.dreamypatisiel.devdevdev.domain.entity.*;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_TECH_ARTICLE_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Bookmark;
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
@@ -28,10 +36,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
 
@@ -71,7 +75,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when
-        Slice<TechArticleMainResponse> techArticles = memberTechArticleService.getTechArticles(pageable, null, null, null, null, authentication);
+        Slice<TechArticleMainResponse> techArticles = memberTechArticleService.getTechArticles(pageable, null, null,
+                null, null, null, authentication);
 
         // then
         assertThat(techArticles)
@@ -92,7 +97,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when // then
-        assertThatThrownBy(() -> memberTechArticleService.getTechArticles(pageable, null, null, null, null, authentication))
+        assertThatThrownBy(
+                () -> memberTechArticleService.getTechArticles(pageable, null, null, null, null, null, authentication))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
@@ -114,7 +120,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when
-        TechArticleDetailResponse techArticleDetailResponse = memberTechArticleService.getTechArticle(id, authentication);
+        TechArticleDetailResponse techArticleDetailResponse = memberTechArticleService.getTechArticle(id,
+                authentication);
 
         // then
         assertThat(techArticleDetailResponse)
@@ -144,15 +151,16 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when
-        TechArticleDetailResponse techArticleDetailResponse = memberTechArticleService.getTechArticle(id, authentication);
+        TechArticleDetailResponse techArticleDetailResponse = memberTechArticleService.getTechArticle(id,
+                authentication);
 
         // then
         assertThat(techArticleDetailResponse)
                 .isNotNull()
                 .isInstanceOf(TechArticleDetailResponse.class)
                 .satisfies(article -> {
-                    assertThat(article.getViewTotalCount() == prevViewTotalCount+1);
-                    assertThat(article.getPopularScore()==prevPopularScore+2);
+                    assertThat(article.getViewTotalCount() == prevViewTotalCount + 1);
+                    assertThat(article.getPopularScore() == prevPopularScore + 2);
                 });
     }
 
@@ -178,10 +186,11 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("회원이 기술블로그 상세를 조회할 때 기술블로그가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundTechArticleException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), null, null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
-        Long id = savedTechArticle.getId()+1;
+        Long id = savedTechArticle.getId() + 1;
 
         SocialMemberDto socialMemberDto = createSocialDto(userId, name, nickname, password, email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
@@ -203,7 +212,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("회원이 기술블로그 상세를 조회할 때 엘라스틱ID가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundElasticIdException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), null, null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
         Long id = savedTechArticle.getId();
@@ -228,7 +238,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
     @DisplayName("회원이 기술블로그 상세를 조회할 때 엘라스틱 기술블로그가 존재하지 않으면 예외가 발생한다.")
     void getTechArticleNotFoundElasticTechArticleException() {
         // given
-        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L), new Count(1L),
+        TechArticle techArticle = TechArticle.of(new Url("https://example.com"), new Count(1L), new Count(1L),
+                new Count(1L),
                 new Count(1L), "elasticId", null);
         TechArticle savedTechArticle = techArticleRepository.save(techArticle);
         Long id = savedTechArticle.getId();
@@ -327,7 +338,8 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         bookmarkRepository.save(bookmark);
 
         // when
-        Slice<TechArticleMainResponse> findTechArticles = memberTechArticleService.getBookmarkedTechArticles(pageable, null, null, authentication);
+        Slice<TechArticleMainResponse> findTechArticles = memberTechArticleService.getBookmarkedTechArticles(pageable,
+                null, null, authentication);
 
         // then
         assertThat(findTechArticles)
@@ -349,12 +361,14 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when // then
-        assertThatThrownBy(() -> memberTechArticleService.getBookmarkedTechArticles(pageable, null, null, authentication))
+        assertThatThrownBy(
+                () -> memberTechArticleService.getBookmarkedTechArticles(pageable, null, null, authentication))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleServiceTest.java
@@ -1,10 +1,17 @@
 package com.dreamypatisiel.devdevdev.elastic.domain.service;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.exception.ElasticTechArticleException;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
+import java.util.Comparator;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,14 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-
-import java.util.Comparator;
-import java.util.List;
-
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
 
@@ -35,7 +34,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, null, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, null,
+                null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -54,10 +54,11 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.LATEST, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.LATEST, null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
-                        .toList();
+                .toList();
 
         // then
         assertThat(elasticTechArticles)
@@ -73,7 +74,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.MOST_VIEWED, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_VIEWED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -92,7 +94,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.MOST_COMMENTED, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_COMMENTED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -111,7 +114,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.POPULAR, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.POPULAR, null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -130,7 +134,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.HIGHEST_SCORE, null, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.HIGHEST_SCORE, null, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -150,7 +155,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when // then
-        assertThatThrownBy(() -> elasticTechArticleService.getTechArticles(pageable, "dontExistElasticId", null, null, null))
+        assertThatThrownBy(
+                () -> elasticTechArticleService.getTechArticles(pageable, "dontExistElasticId", null, null, null, null))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE);
     }
@@ -162,14 +168,16 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.LATEST,null, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.LATEST, null, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.LATEST, null, null);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.LATEST, null, null, null);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -189,14 +197,16 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.MOST_VIEWED, null, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.MOST_VIEWED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.MOST_VIEWED, null, null);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.MOST_VIEWED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -216,14 +226,16 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.MOST_COMMENTED, null, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.MOST_COMMENTED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.MOST_COMMENTED, null, null);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.MOST_COMMENTED, null, null, null);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -243,14 +255,16 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.POPULAR, null, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.POPULAR, null, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.POPULAR, null, null);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.POPULAR, null, null, null);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -270,14 +284,16 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.HIGHEST_SCORE,null, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.HIGHEST_SCORE, null, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.HIGHEST_SCORE, null, null);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.HIGHEST_SCORE, null, null, null);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -298,7 +314,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, null, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, null,
+                keyword, null, null);
         List<Float> elasticTechArticlesScores = techArticles.getSearchHits().stream()
                 .map(SearchHit::getScore)
                 .toList();
@@ -319,7 +336,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.HIGHEST_SCORE, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.HIGHEST_SCORE, keyword, null, null);
         List<Float> elasticTechArticlesScores = techArticles.getSearchHits().stream()
                 .map(SearchHit::getScore)
                 .toList();
@@ -340,7 +358,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.LATEST, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.LATEST, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -362,7 +381,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.MOST_VIEWED, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_VIEWED, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -384,7 +404,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.MOST_COMMENTED, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_COMMENTED, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -406,7 +427,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null, TechArticleSort.POPULAR, keyword, null);
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.POPULAR, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -428,7 +450,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.HIGHEST_SCORE,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.HIGHEST_SCORE, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -439,7 +462,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.HIGHEST_SCORE, keyword, cursorScore);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.HIGHEST_SCORE, keyword, null, cursorScore);
         List<Float> elasticTechArticleScores2 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getScore)
                 .toList();
@@ -461,14 +485,17 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.HIGHEST_SCORE,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.HIGHEST_SCORE, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when // then
-        assertThatThrownBy(() -> elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.HIGHEST_SCORE, keyword, null))
+        assertThatThrownBy(
+                () -> elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.HIGHEST_SCORE,
+                        keyword, null, null))
                 .isInstanceOf(ElasticTechArticleException.class)
                 .hasMessage(NOT_FOUND_CURSOR_SCORE_MESSAGE);
     }
@@ -481,7 +508,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.LATEST,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.LATEST, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -492,7 +520,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.LATEST, keyword, cursorScore);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.LATEST, keyword, null, cursorScore);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -516,7 +545,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.MOST_VIEWED,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.MOST_VIEWED, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -527,7 +557,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.MOST_VIEWED, keyword, cursorScore);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.MOST_VIEWED, keyword, null, cursorScore);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -550,7 +581,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.MOST_COMMENTED,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.MOST_COMMENTED, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -561,7 +593,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.MOST_COMMENTED, keyword, cursorScore);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.MOST_COMMENTED, keyword, null, cursorScore);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -584,7 +617,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null, TechArticleSort.POPULAR,keyword, null);
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(prevPageable, null,
+                TechArticleSort.POPULAR, keyword, null, null);
         List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -595,7 +629,8 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable, cursor.getId(), TechArticleSort.POPULAR, keyword, cursorScore);
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+                cursor.getId(), TechArticleSort.POPULAR, keyword, null, cursorScore);
         List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
                 .map(SearchHit::getContent)
                 .toList();
@@ -606,6 +641,98 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
 
         assertThat(elasticTechArticles2)
                 .hasSize(pageable.getPageSize())
+                .extracting(ElasticTechArticle::getPopularScore)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    @Test
+    @DisplayName("엘라스틱서치 기술블로그 메인을 회사로 필터링한 후 최신순으로 조회한다.")
+    void getTechArticlesFilterByCompanyOrderByLATEST() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.LATEST, null, COMPANY_ID, null);
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+
+        // then
+        assertThat(elasticTechArticles)
+                .hasSize(pageable.getPageSize())
+                .allSatisfy(article -> {
+                    assertThat(article.getCompanyId()).isEqualTo(COMPANY_ID);
+                })
+                .extracting(ElasticTechArticle::getRegDate)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    @Test
+    @DisplayName("엘라스틱서치 기술블로그 메인을 회사로 필터링한 후 조회수 내림차순으로 조회한다.")
+    void getTechArticlesFilterByCompanyOrderByMOST_VIEWED() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_VIEWED, null, COMPANY_ID, null);
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+
+        // then
+        assertThat(elasticTechArticles)
+                .hasSize(pageable.getPageSize())
+                .allSatisfy(article -> {
+                    assertThat(article.getCompanyId()).isEqualTo(COMPANY_ID);
+                })
+                .extracting(ElasticTechArticle::getViewTotalCount)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    @Test
+    @DisplayName("엘라스틱서치 기술블로그 메인을 회사로 필터링한 후 댓글수 내림차순으로 조회한다.")
+    void getTechArticlesFilterByCompanyOrderByMOST_COMMENTED() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.MOST_COMMENTED, null, COMPANY_ID, null);
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+
+        // then
+        assertThat(elasticTechArticles)
+                .hasSize(pageable.getPageSize())
+                .allSatisfy(article -> {
+                    assertThat(article.getCompanyId()).isEqualTo(COMPANY_ID);
+                })
+                .extracting(ElasticTechArticle::getCommentTotalCount)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    @Test
+    @DisplayName("엘라스틱서치 기술블로그 메인을 회사로 필터링한 후 인기점수 내림차순으로 조회한다.")
+    void getTechArticlesFilterByCompanyOrderByPOPULAR_SCORE() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable, null,
+                TechArticleSort.POPULAR, null, COMPANY_ID, null);
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .toList();
+
+        // then
+        assertThat(elasticTechArticles)
+                .hasSize(pageable.getPageSize())
+                .allSatisfy(article -> {
+                    assertThat(article.getCompanyId()).isEqualTo(COMPANY_ID);
+                })
                 .extracting(ElasticTechArticle::getPopularScore)
                 .isSortedAccordingTo(Comparator.reverseOrder());
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
@@ -8,17 +8,16 @@ import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 //@ExtendWith(ContainerExtension.class)
 //@SpringBootTest(classes = {ElasticsearchTestConfig.class})
@@ -29,20 +28,26 @@ public class ElasticsearchSupportTest {
     public static final int TEST_ARTICLES_COUNT = 20;
     public static Long FIRST_TECH_ARTICLE_ID;
     public static TechArticle firstTechArticle;
+    public static Long COMPANY_ID;
 
     @BeforeAll
     static void setup(@Autowired TechArticleRepository techArticleRepository,
                       @Autowired CompanyRepository companyRepository,
                       @Autowired ElasticTechArticleRepository elasticTechArticleRepository) {
 
+        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
+                new Url("https://example.com"));
+        Company savedCompany = companyRepository.save(company);
+
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
         for (int i = 1; i <= TEST_ARTICLES_COUNT; i++) {
-            ElasticTechArticle elasticTechArticle = ElasticTechArticle.of("타이틀"+i, createRandomDate(), "내용", "http://example.com/"+i, "설명", "http://example.com/", "작성자", "회사", (long)i, (long)i, (long)i, (long)i*10);
+            ElasticTechArticle elasticTechArticle = createElasticTechArticle("타이틀" + i, createRandomDate(), "내용",
+                    "http://example.com/" + i, "설명", "http://example.com/", "작성자", company.getId(),
+                    company.getName().getCompanyName(), (long) i, (long) i, (long) i, (long) i * 10);
             elasticTechArticles.add(elasticTechArticle);
         }
-        Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(elasticTechArticles);
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"), new Url("https://example.com"));
-        Company savedCompany = companyRepository.save(company);
+        Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
+                elasticTechArticles);
 
         List<TechArticle> techArticles = new ArrayList<>();
         for (ElasticTechArticle elasticTechArticle : elasticTechArticleIterable) {
@@ -52,6 +57,7 @@ public class ElasticsearchSupportTest {
         List<TechArticle> savedTechArticles = techArticleRepository.saveAll(techArticles);
         firstTechArticle = savedTechArticles.getFirst();
         FIRST_TECH_ARTICLE_ID = firstTechArticle.getId();
+        COMPANY_ID = savedCompany.getId();
     }
 
     @AfterAll
@@ -70,5 +76,29 @@ public class ElasticsearchSupportTest {
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
 
         return startDate.plusDays(randomDays);
+    }
+
+    private static ElasticTechArticle createElasticTechArticle(String title, LocalDate regDate, String contents,
+                                                               String techArticleUrl,
+                                                               String description, String thumbnailUrl, String author,
+                                                               Long companyId, String company,
+                                                               Long viewTotalCount, Long recommendTotalCount,
+                                                               Long commentTotalCount,
+                                                               Long popularScore) {
+        return ElasticTechArticle.builder()
+                .title(title)
+                .regDate(regDate)
+                .contents(contents)
+                .techArticleUrl(techArticleUrl)
+                .description(description)
+                .thumbnailUrl(thumbnailUrl)
+                .author(author)
+                .companyId(companyId)
+                .company(company)
+                .viewTotalCount(viewTotalCount)
+                .recommendTotalCount(recommendTotalCount)
+                .commentTotalCount(commentTotalCount)
+                .popularScore(popularScore)
+                .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -63,7 +63,7 @@ class MyPageControllerTest extends SupportControllerTest {
 
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
         for (int i = 1; i <= 20; i++) {
-            ElasticTechArticle elasticTechArticle = ElasticTechArticle.of("타이틀" + i, createRandomDate(), "내용",
+            ElasticTechArticle elasticTechArticle = createElasticTechArticle("타이틀" + i, createRandomDate(), "내용",
                     "http://example.com/" + i, "설명", "http://example.com/", "작성자", "DP", (long) i, (long) i, (long) i,
                     (long) i * 10);
             elasticTechArticles.add(elasticTechArticle);
@@ -269,5 +269,28 @@ class MyPageControllerTest extends SupportControllerTest {
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
 
         return startDate.plusDays(randomDays);
+    }
+
+    private static ElasticTechArticle createElasticTechArticle(String title, LocalDate regDate, String contents,
+                                                               String techArticleUrl,
+                                                               String description, String thumbnailUrl, String author,
+                                                               String company,
+                                                               Long viewTotalCount, Long recommendTotalCount,
+                                                               Long commentTotalCount,
+                                                               Long popularScore) {
+        return ElasticTechArticle.builder()
+                .title(title)
+                .regDate(regDate)
+                .contents(contents)
+                .techArticleUrl(techArticleUrl)
+                .description(description)
+                .thumbnailUrl(thumbnailUrl)
+                .author(author)
+                .company(company)
+                .viewTotalCount(viewTotalCount)
+                .recommendTotalCount(recommendTotalCount)
+                .commentTotalCount(commentTotalCount)
+                .popularScore(popularScore)
+                .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -79,7 +79,7 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
 
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
         for (int i = 1; i <= 1; i++) {
-            ElasticTechArticle elasticTechArticle = ElasticTechArticle.of("타이틀" + i, createRandomDate(), "내용",
+            ElasticTechArticle elasticTechArticle = createElasticTechArticle("타이틀" + i, createRandomDate(), "내용",
                     "http://example.com/" + i, "설명", "http://example.com/", "작성자", "회사", (long) i, (long) i, (long) i,
                     (long) i * 10);
             elasticTechArticles.add(elasticTechArticle);
@@ -278,5 +278,28 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
 
         return startDate.plusDays(randomDays);
+    }
+
+    private static ElasticTechArticle createElasticTechArticle(String title, LocalDate regDate, String contents,
+                                                               String techArticleUrl,
+                                                               String description, String thumbnailUrl, String author,
+                                                               String company,
+                                                               Long viewTotalCount, Long recommendTotalCount,
+                                                               Long commentTotalCount,
+                                                               Long popularScore) {
+        return ElasticTechArticle.builder()
+                .title(title)
+                .regDate(regDate)
+                .contents(contents)
+                .techArticleUrl(techArticleUrl)
+                .description(description)
+                .thumbnailUrl(thumbnailUrl)
+                .author(author)
+                .company(company)
+                .viewTotalCount(viewTotalCount)
+                .recommendTotalCount(recommendTotalCount)
+                .commentTotalCount(commentTotalCount)
+                .popularScore(popularScore)
+                .build();
     }
 }


### PR DESCRIPTION
## 추가 기능
- 기술블로그 메인 API query param에 companyId를 추가하여, 각 회사에 대한 필터 기능을 사용할 수 있도록 했습니다.

## 주요 변경 사항
- companyId가 있다면 쿼리에 필터를 추가합니다.

- TechArticleCommonService > getTechArticlesByElasticIdsIn() 메소드에 아래 조건문을 추가하여, 조회된 elasticIds의 길이가 0이라면 **불필요한 쿼리를 실행하지 않도록 했습니다.**
```java
    protected List<TechArticle> getTechArticlesByElasticIdsIn(
            List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {
        List<String> elasticIds = getElasticIds(elasticTechArticlesResponse);

        // 추출한 elasticId가 없다면 빈 리스트 응답
        if (elasticIds.isEmpty()) {
            return Collections.emptyList();
        }
        
        return techArticleRepository.findAllByElasticIdIn(elasticIds);
    }
```
- Guest/MemberTechArticleService > mapToTechArticlesResponse() 메소드에 아래 조건문을 추가하여, 조회 결과가 없다면 **불필요한 가공 로직을 거치지 않고 바로 빈 리스트를 반환**하도록 하였습니다.
```java
    private List<TechArticleMainResponse> mapToTechArticlesResponse(
            List<ElasticResponse<ElasticTechArticle>> elasticTechArticlesResponse) {

        // 조회 결과가 없을 경우 빈 리스트 응답
        if (elasticTechArticlesResponse.isEmpty()) {
            return Collections.emptyList();
        }

       ...
   }
```