### PR TITLE
[DP-93] 신규 가입시 닉네임 자동생성

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
@@ -3,6 +3,7 @@ package com.dreamypatisiel.devdevdev;
 import com.dreamypatisiel.devdevdev.domain.entity.Bookmark;
 import com.dreamypatisiel.devdevdev.domain.entity.Company;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
 import com.dreamypatisiel.devdevdev.domain.entity.Pick;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOption;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOptionImage;
@@ -13,14 +14,17 @@ import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.PickOptionContents;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Title;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Word;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.ContentStatus;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.MemberNicknameDictionaryRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
@@ -74,6 +78,7 @@ public class LocalInitData {
     private final BookmarkRepository bookmarkRepository;
     private final ElasticTechArticleRepository elasticTechArticleRepository;
     private final CompanyRepository companyRepository;
+    private final MemberNicknameDictionaryRepository memberNicknameDictionaryRepository;
 
     @EventListener(ApplicationReadyEvent.class)
     public void dataInsert() {
@@ -104,6 +109,26 @@ public class LocalInitData {
 
         List<Bookmark> bookmarks = createBookmarks(member, techArticles);
         bookmarkRepository.saveAll(bookmarks);
+
+        List<MemberNicknameDictionary> nicknameDictionaryWords = createNicknameDictionaryWords();
+        memberNicknameDictionaryRepository.saveAll(nicknameDictionaryWords);
+    }
+
+    private List<MemberNicknameDictionary> createNicknameDictionaryWords() {
+        List<MemberNicknameDictionary> nicknameDictionaryWords = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            for (WordType wordType : WordType.values()) {
+                nicknameDictionaryWords.add(createMemberNicknameDictionary(wordType.getType() + i, wordType));
+            }
+        }
+        return nicknameDictionaryWords;
+    }
+
+    private static MemberNicknameDictionary createMemberNicknameDictionary(String word, WordType wordType) {
+        return MemberNicknameDictionary.builder()
+                .word(new Word(word))
+                .wordType(wordType)
+                .build();
     }
 
     private static SocialMemberDto createSocialMemberDto(String username, String userEmail, String userNickname,

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -1,17 +1,30 @@
 package com.dreamypatisiel.devdevdev.domain.entity;
 
-import com.dreamypatisiel.devdevdev.domain.entity.embedded.*;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.AnnualIncome;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Experience;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Nickname;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -45,19 +58,25 @@ public class Member extends BasicTime {
     private String userId;
 
     private String profileImage;
+
     private String job;
+
     @Embedded
     private AnnualIncome annualIncome;
+
     @Embedded
     private Experience experience;
+
     private Boolean subscriptionLetterGranted;
 
     private String refreshToken;
+
     @Embedded
     @AttributeOverride(name = "email",
             column = @Column(name = "subscription_letter_email")
     )
     private Email subscriptionLetterEmail;
+
     private LocalDateTime loginDate;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/MemberNicknameDictionary.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/MemberNicknameDictionary.java
@@ -29,7 +29,7 @@ public class MemberNicknameDictionary extends BasicTime {
     private WordType wordType;
 
     @Builder
-    public MemberNicknameDictionary(Word word, WordType wordType) {
+    private MemberNicknameDictionary(Word word, WordType wordType) {
         this.word = word;
         this.wordType = wordType;
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/MemberNicknameDictionary.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/MemberNicknameDictionary.java
@@ -1,0 +1,36 @@
+package com.dreamypatisiel.devdevdev.domain.entity;
+
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Word;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberNicknameDictionary extends BasicTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private Word word;
+
+    @Enumerated(value = EnumType.STRING)
+    private WordType wordType;
+
+    @Builder
+    public MemberNicknameDictionary(Word word, WordType wordType) {
+        this.word = word;
+        this.wordType = wordType;
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/embedded/Word.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/embedded/Word.java
@@ -1,0 +1,40 @@
+package com.dreamypatisiel.devdevdev.domain.entity.embedded;
+
+import com.dreamypatisiel.devdevdev.exception.TitleException;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class Word {
+    public static final String INVALID_WORD_MESSAGE = "단어는 빈 값이거나 %d자를 초과 할 수 없습니다.";
+    public static final int MAX_WORD_LENGTH = 10;
+    public static final int MIN_WORD_LENGTH = 1;
+
+    private String word;
+
+    public Word(String word) {
+        validationWord(word);
+        this.word = word;
+    }
+
+    private void validationWord(String word) {
+        if (!isValidWordLength(word)) {
+            throw new TitleException(getInvalidWordExceptionMessage());
+        }
+    }
+
+    private boolean isValidWordLength(String title) {
+        return StringUtils.hasText(title) && title.length() <= MAX_WORD_LENGTH;
+    }
+
+    public static String getInvalidWordExceptionMessage() {
+        return String.format(INVALID_WORD_MESSAGE, MAX_WORD_LENGTH);
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/enums/WordType.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/enums/WordType.java
@@ -1,0 +1,15 @@
+package com.dreamypatisiel.devdevdev.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WordType {
+    ADVERB("부사", 1),
+    ADJECTIVE("형용사", 2),
+    NOUN("명사", 3);
+
+    private final String type;
+    private final int priority;
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/MemberRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/MemberRepository.java
@@ -1,15 +1,18 @@
-package com.dreamypatisiel.devdevdev.domain.repository;
+package com.dreamypatisiel.devdevdev.domain.repository.member;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
-import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByUserIdAndSocialType(String userId, SocialType socialType);
+
     List<Member> findMembersByUserIdAndSocialType(String userId, SocialType socialType);
+
     Optional<Member> findMemberByEmailAndSocialType(Email email, SocialType socialType);
+
     Optional<Member> findMemberByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/MemberNicknameDictionaryRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/MemberNicknameDictionaryRepository.java
@@ -1,0 +1,9 @@
+package com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary;
+
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
+import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.custom.MemberNicknameDictionaryRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberNicknameDictionaryRepository extends JpaRepository<MemberNicknameDictionary, Long>,
+        MemberNicknameDictionaryRepositoryCustom {
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.custom;
+
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
+import java.util.Optional;
+
+public interface MemberNicknameDictionaryRepositoryCustom {
+    Optional<MemberNicknameDictionary> findRandomByWordType(WordType wordType);
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryCustom.java
@@ -5,5 +5,5 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
 import java.util.Optional;
 
 public interface MemberNicknameDictionaryRepositoryCustom {
-    Optional<MemberNicknameDictionary> findRandomByWordType(WordType wordType);
+    Optional<MemberNicknameDictionary> findRandomWordByWordType(WordType wordType);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.custom;
+
+import static com.dreamypatisiel.devdevdev.domain.entity.QMemberNicknameDictionary.memberNicknameDictionary;
+
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPQLQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberNicknameDictionaryRepositoryImpl implements MemberNicknameDictionaryRepositoryCustom {
+
+    private final JPQLQueryFactory query;
+
+    @Override
+    public Optional<MemberNicknameDictionary> findRandomByWordType(WordType wordType) {
+
+        MemberNicknameDictionary findWord = query.selectFrom(memberNicknameDictionary)
+                .where(memberNicknameDictionary.wordType.eq(wordType))
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .fetchFirst();
+        return Optional.ofNullable(findWord);
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/memberNicknameDictionary/custom/MemberNicknameDictionaryRepositoryImpl.java
@@ -15,7 +15,7 @@ public class MemberNicknameDictionaryRepositoryImpl implements MemberNicknameDic
     private final JPQLQueryFactory query;
 
     @Override
-    public Optional<MemberNicknameDictionary> findRandomByWordType(WordType wordType) {
+    public Optional<MemberNicknameDictionary> findRandomWordByWordType(WordType wordType) {
 
         MemberNicknameDictionary findWord = query.selectFrom(memberNicknameDictionary)
                 .where(memberNicknameDictionary.wordType.eq(wordType))

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
@@ -1,0 +1,53 @@
+package com.dreamypatisiel.devdevdev.domain.service.member;
+
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
+import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.MemberNicknameDictionaryRepository;
+import com.dreamypatisiel.devdevdev.exception.NotFoundException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberNicknameDictionaryService {
+
+    public static final String NOT_FOUND_WORD_EXCEPTION_MESSAGE = "랜덤 닉네임 생성을 위한 단어가 없습니다.";
+    private final MemberNicknameDictionaryRepository memberNicknameDictionaryRepository;
+
+    /**
+     * 랜덤 닉네임을 생성합니다.
+     */
+    public String createRandomNickname() {
+        List<MemberNicknameDictionary> nicknameDictionaryWords = new ArrayList<>();
+
+        // WordType 우선순위에 따라 랜덤 단어를 1개씩 뽑습니다.
+        Stream.of(WordType.values())
+                .sorted(Comparator.comparingInt(WordType::getPriority)) // 우선순위에 따라 정렬
+                .map(wordType -> memberNicknameDictionaryRepository.findRandomByWordType(wordType)
+                        .orElseThrow(() -> new NotFoundException(NOT_FOUND_WORD_EXCEPTION_MESSAGE)))
+                .forEach(nicknameDictionaryWords::add);
+
+        return concatNickname(nicknameDictionaryWords);
+    }
+    
+    private String concatNickname(List<MemberNicknameDictionary> words) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < words.size(); i++) {
+            MemberNicknameDictionary word = words.get(i);
+            sb.append(word.getWord().getWord());
+
+            if (i < words.size() - 1) {
+                sb.append(" ");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
@@ -4,9 +4,9 @@ import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
 import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.MemberNicknameDictionaryRepository;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,18 +26,20 @@ public class MemberNicknameDictionaryService {
      * 랜덤 닉네임을 생성합니다.
      */
     public String createRandomNickname() {
-        List<MemberNicknameDictionary> nicknameDictionaryWords = new ArrayList<>();
-
         // WordType 우선순위에 따라 랜덤 단어를 1개씩 뽑습니다.
-        Stream.of(WordType.values())
+        List<MemberNicknameDictionary> nicknameDictionaryWords = Stream.of(WordType.values())
                 .sorted(Comparator.comparingInt(WordType::getPriority)) // 우선순위에 따라 정렬
-                .map(wordType -> memberNicknameDictionaryRepository.findRandomByWordType(wordType)
-                        .orElseThrow(() -> new NotFoundException(NOT_FOUND_WORD_EXCEPTION_MESSAGE)))
-                .forEach(nicknameDictionaryWords::add);
+                .map(this::findRandomWordByWordType)
+                .collect(Collectors.toList());
 
         return concatNickname(nicknameDictionaryWords);
     }
-    
+
+    private MemberNicknameDictionary findRandomWordByWordType(WordType wordType) {
+        return memberNicknameDictionaryRepository.findRandomWordByWordType(wordType)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_WORD_EXCEPTION_MESSAGE));
+    }
+
     private String concatNickname(List<MemberNicknameDictionary> words) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < words.size(); i++) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryService.java
@@ -41,15 +41,8 @@ public class MemberNicknameDictionaryService {
     }
 
     private String concatNickname(List<MemberNicknameDictionary> words) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < words.size(); i++) {
-            MemberNicknameDictionary word = words.get(i);
-            sb.append(word.getWord().getWord());
-
-            if (i < words.size() - 1) {
-                sb.append(" ");
-            }
-        }
-        return sb.toString();
+        return words.stream()
+                .map(word -> word.getWord().getWord())
+                .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
@@ -3,7 +3,7 @@ package com.dreamypatisiel.devdevdev.global.common;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
@@ -23,7 +23,7 @@ public class MemberProvider {
 
     public Member getMemberByAuthentication(Authentication authentication) {
 
-        if(AuthenticationMemberUtils.isAnonymous(authentication)) {
+        if (AuthenticationMemberUtils.isAnonymous(authentication)) {
             throw new IllegalStateException(INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE);
         }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
@@ -3,9 +3,9 @@ package com.dreamypatisiel.devdevdev.global.security.jwt.service;
 import static com.dreamypatisiel.devdevdev.exception.TokenInvalidException.REFRESH_TOKEN_INVALID_EXCEPTION_MESSAGE;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
-import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.exception.TokenInvalidException;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtClaimConstant;
@@ -25,13 +25,11 @@ public class JwtMemberService {
     private final TokenService tokenService;
 
     /**
-     * 리프레시 토큰을 검증하고,
-     * 새로운 토큰을 생성하고,
-     * 새롭게 생성한 리프레시 토큰으로 회원을 갱신하고
-     * 새롭게 생성한 토큰을 반환한다.
+     * 리프레시 토큰을 검증하고, 새로운 토큰을 생성하고, 새롭게 생성한 리프레시 토큰으로 회원을 갱신하고 새롭게 생성한 토큰을 반환한다.
      */
     @Transactional
-    public Token validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(String refreshToken) throws TokenInvalidException {
+    public Token validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(String refreshToken)
+            throws TokenInvalidException {
 
         // 토큰 검증
         tokenService.validateToken(refreshToken);
@@ -40,11 +38,12 @@ public class JwtMemberService {
         String socialType = tokenService.getSocialType(refreshToken);
 
         // 회원 조회
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email), SocialType.valueOf(socialType))
+        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email),
+                        SocialType.valueOf(socialType))
                 .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
 
         // 회원이 가지고 있는 리프레시 토큰과 일치 하는지?
-        if(!findMember.isRefreshTokenEquals(refreshToken)) {
+        if (!findMember.isRefreshTokenEquals(refreshToken)) {
             throw new TokenInvalidException(REFRESH_TOKEN_INVALID_EXCEPTION_MESSAGE);
         }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/SocialMemberDto.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/SocialMemberDto.java
@@ -16,7 +16,8 @@ public class SocialMemberDto {
     private Role role;
 
     @Builder
-    private SocialMemberDto(String userId, String name, String email, String nickname, String password, SocialType socialType, Role role) {
+    private SocialMemberDto(String userId, String name, String email, String nickname, String password,
+                            SocialType socialType, Role role) {
         this.userId = userId;
         this.name = name;
         this.email = email;
@@ -53,5 +54,9 @@ public class SocialMemberDto {
                 .role(Role.valueOf(role))
                 .nickname(nickname)
                 .build();
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
@@ -3,7 +3,8 @@ package com.dreamypatisiel.devdevdev.global.security.oauth2.service;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Password;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.service.member.MemberNicknameDictionaryService;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.OAuth2UserProvider;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
@@ -20,17 +21,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuth2MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MemberNicknameDictionaryService memberNicknameDictionaryService;
 
     @Transactional
     public UserPrincipal register(OAuth2UserProvider oAuth2UserProvider, OAuth2User oAuth2User) {
         Optional<Member> optionalMember = findMemberByOAuth2UserProvider(oAuth2UserProvider);
-        if(optionalMember.isPresent()) {
+        if (optionalMember.isPresent()) {
             return UserPrincipal.createByMemberAndAttributes(optionalMember.get(), oAuth2User.getAttributes());
         }
 
         // 데이터베이스 회원이 없으면 회원가입 시킨다.
         String encodePassword = passwordEncoder.encode(new Password().getPassword());
         SocialMemberDto socialMemberDto = SocialMemberDto.from(oAuth2UserProvider, encodePassword);
+
+        // 랜덤 닉네임 생성
+        String randomNickname = memberNicknameDictionaryService.createRandomNickname();
+        socialMemberDto.setNickname(randomNickname);
+
         Member newMember = memberRepository.save(Member.createMemberBy(socialMemberDto));
 
         return UserPrincipal.createByMemberAndAttributes(newMember, oAuth2User.getAttributes());

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechArticleRepositoryTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechArticleRepositoryTest.java
@@ -9,7 +9,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import jakarta.persistence.EntityManager;
 import java.util.List;

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberNicknameDictionaryServiceTest.java
@@ -1,0 +1,52 @@
+package com.dreamypatisiel.devdevdev.domain.service.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Word;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
+import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.MemberNicknameDictionaryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberNicknameDictionaryServiceTest {
+
+    @Autowired
+    MemberNicknameDictionaryService memberNicknameDictionaryService;
+    @Autowired
+    MemberNicknameDictionaryRepository memberNicknameDictionaryRepository;
+
+    @Test
+    @DisplayName("WordType 우선순위에 따라 랜덤 닉네임이 생성된다.")
+    void test() {
+        // given
+        List<MemberNicknameDictionary> nicknameDictionaryWords = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            for (WordType wordType : WordType.values()) {
+                nicknameDictionaryWords.add(createMemberNicknameDictionary(wordType.getType() + i, wordType));
+            }
+        }
+        memberNicknameDictionaryRepository.saveAll(nicknameDictionaryWords);
+
+        // when
+        String randomNickname = memberNicknameDictionaryService.createRandomNickname();
+
+        // then
+        assertThat(randomNickname.split(" "))
+                .hasSize(WordType.values().length);
+    }
+
+    private static MemberNicknameDictionary createMemberNicknameDictionary(String word, WordType wordType) {
+        return MemberNicknameDictionary.builder()
+                .word(new Word(word))
+                .wordType(wordType)
+                .build();
+    }
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickServiceTest.java
@@ -22,7 +22,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
@@ -34,7 +34,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
@@ -14,7 +14,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.service.response.BookmarkResponse;
 import com.dreamypatisiel.devdevdev.domain.service.response.TechArticleDetailResponse;

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/common/MemberProviderTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/common/MemberProviderTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.when;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
@@ -88,7 +88,8 @@ class MemberProviderTest {
                 .hasMessage(MemberProvider.INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE);
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.exception.TokenInvalidException;
 import com.dreamypatisiel.devdevdev.global.common.TimeProvider;
@@ -65,7 +65,8 @@ class JwtMemberServiceTest {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
-        when(timeProvider.getDateNow()).thenReturn(new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
+        when(timeProvider.getDateNow()).thenReturn(
+                new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
 
         // when
         Token token = jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(refreshToken);
@@ -97,7 +98,8 @@ class JwtMemberServiceTest {
         String otherRefreshToken = token.getRefreshToken();
 
         // when // then
-        assertThatThrownBy(() -> jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(otherRefreshToken))
+        assertThatThrownBy(() -> jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(
+                otherRefreshToken))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
@@ -112,12 +114,14 @@ class JwtMemberServiceTest {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
-        when(timeProvider.getDateNow()).thenReturn(new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
+        when(timeProvider.getDateNow()).thenReturn(
+                new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
         Token token = tokenService.generateTokenBy(email, socialType, role);
         String otherRefreshToken = token.getRefreshToken();
 
         // when // then
-        assertThatThrownBy(() -> jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(otherRefreshToken))
+        assertThatThrownBy(() -> jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(
+                otherRefreshToken))
                 .isInstanceOf(TokenInvalidException.class)
                 .hasMessage(TokenInvalidException.REFRESH_TOKEN_INVALID_EXCEPTION_MESSAGE);
     }
@@ -132,7 +136,8 @@ class JwtMemberServiceTest {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
-        when(timeProvider.getDateNow()).thenReturn(new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
+        when(timeProvider.getDateNow()).thenReturn(
+                new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
         Token token = tokenService.generateTokenBy(email, socialType, role);
         String otherRefreshToken = token.getRefreshToken();
 
@@ -157,7 +162,8 @@ class JwtMemberServiceTest {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
-        when(timeProvider.getDateNow()).thenReturn(new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
+        when(timeProvider.getDateNow()).thenReturn(
+                new Date(date.getTime() + TokenExpireTime.REFRESH_TOKEN_EXPIRE_TIME));
         String otherEmail = "ralph@kakao.com";
         Token token = tokenService.generateTokenBy(otherEmail, socialType, role);
         String otherRefreshToken = token.getRefreshToken();
@@ -202,7 +208,8 @@ class JwtMemberServiceTest {
                 .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.KakaoMember;
@@ -121,7 +121,7 @@ class OAuth2SuccessHandlerTest {
     }
 
     private static SocialMemberDto createSocialMemberDto(String userId, String email, String password,
-                                                      SocialType socialType, Role role) {
+                                                         SocialType socialType, Role role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(userId)

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
@@ -6,17 +6,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
-import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Nickname;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
-
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.KakaoMember;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.OAuth2UserProvider;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
-
 import java.util.HashMap;
-
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -80,7 +77,6 @@ class AppOAuth2MemberServiceTest {
         when(mockOAuth2UserProvider.getUserName()).thenReturn(userName);
         when(mockOAuth2UserProvider.getSocialType()).thenReturn(socialType);
         when(mockOAuth2UserProvider.getEmail()).thenReturn(email);
-
 
         OAuth2User mockOAuth2User = mock(OAuth2User.class);
         Map<String, Object> attributes = new HashMap<>();

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
@@ -6,13 +6,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.MemberNicknameDictionary;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Nickname;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Word;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.WordType;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.memberNicknameDictionary.MemberNicknameDictionaryRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.KakaoMember;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.OAuth2UserProvider;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +36,8 @@ class AppOAuth2MemberServiceTest {
     MemberRepository memberRepository;
     @Autowired
     OAuth2MemberService oAuth2MemberService;
+    @Autowired
+    MemberNicknameDictionaryRepository memberNicknameDictionaryRepository;
 
     @Test
     @DisplayName("가입한 이력이 없으면 데이터베이스에 회원을 저장한다.")
@@ -53,6 +60,14 @@ class AppOAuth2MemberServiceTest {
         kakaoAttributes.put(KakaoMember.EMAIL, email);
         attributes.put(KakaoMember.KAKAO_ACCOUNT, kakaoAttributes);
         when(mockOAuth2User.getAttributes()).thenReturn(attributes);
+
+        List<MemberNicknameDictionary> nicknameDictionaryWords = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            for (WordType wordType : WordType.values()) {
+                nicknameDictionaryWords.add(createMemberNicknameDictionary(wordType.getType() + i, wordType));
+            }
+        }
+        memberNicknameDictionaryRepository.saveAll(nicknameDictionaryWords);
 
         // when
         oAuth2MemberService.register(mockOAuth2UserProvider, mockOAuth2User);
@@ -98,5 +113,12 @@ class AppOAuth2MemberServiceTest {
                 .contains(
                         tuple(userId, userName, new Email(email), new Nickname(userName))
                 );
+    }
+
+    private static MemberNicknameDictionary createMemberNicknameDictionary(String word, WordType wordType) {
+        return MemberNicknameDictionary.builder()
+                .word(new Word(word))
+                .wordType(wordType)
+                .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/LogoutControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/LogoutControllerTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
@@ -68,7 +68,8 @@ class LogoutControllerTest extends SupportControllerTest {
         assertThat(findMember.getRefreshToken()).isEqualTo(Token.DISABLED);
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -16,7 +16,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/PickControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/PickControllerTest.java
@@ -36,7 +36,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
@@ -22,7 +22,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TokenControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TokenControllerTest.java
@@ -13,17 +13,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
-
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.response.ResultType;
 import jakarta.servlet.http.Cookie;
 import java.util.Date;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,7 +102,8 @@ class TokenControllerTest extends SupportControllerTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail), SocialType.valueOf(socialType)).get();
+        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail),
+                SocialType.valueOf(socialType)).get();
         mockMvc.perform(get("/devdevdev/api/v1/token/test/user")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -115,6 +114,7 @@ class TokenControllerTest extends SupportControllerTest {
                 // 해당 테스트 계정의 리프레시 토큰이 갱신 되었는지 확인
                 .andExpect(jsonPath("$.data.refreshToken").value(findMember.getRefreshToken()));
     }
+
     @Test
     @DisplayName("ADMIN 테스트 계정의 토큰을 생성하고 해당 계정의 refresh 토큰을 갱신한다.")
     void createAdminToken() throws Exception {
@@ -126,7 +126,8 @@ class TokenControllerTest extends SupportControllerTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail), SocialType.valueOf(socialType)).get();
+        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail),
+                SocialType.valueOf(socialType)).get();
         mockMvc.perform(get("/devdevdev/api/v1/token/test/admin")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -138,7 +139,8 @@ class TokenControllerTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.data.refreshToken").value(findMember.getRefreshToken()));
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/JwtExceptionDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/JwtExceptionDocsTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +40,8 @@ public class JwtExceptionDocsTest extends SupportControllerDocsTest {
         // when // then
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/user")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + invalidSignatureAccessToken))
+                        .header(SecurityConstant.AUTHORIZATION_HEADER,
+                                SecurityConstant.BEARER_PREFIX + invalidSignatureAccessToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
 
@@ -68,7 +69,8 @@ public class JwtExceptionDocsTest extends SupportControllerDocsTest {
         // when // then
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/user")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + invalidExpiredAccessToken))
+                        .header(SecurityConstant.AUTHORIZATION_HEADER,
+                                SecurityConstant.BEARER_PREFIX + invalidExpiredAccessToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
 
@@ -111,7 +113,8 @@ public class JwtExceptionDocsTest extends SupportControllerDocsTest {
         );
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/LogoutControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/LogoutControllerDocsTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
@@ -109,7 +109,8 @@ public class LogoutControllerDocsTest extends SupportControllerDocsTest {
         ));
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -29,7 +29,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickControllerDocsTest.java
@@ -57,7 +57,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -32,7 +32,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TokenControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TokenControllerDocsTest.java
@@ -3,7 +3,6 @@ package com.dreamypatisiel.devdevdev.web.docs;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_ACCESS_TOKEN;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;
 import static org.mockito.Mockito.when;
-
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
@@ -19,10 +18,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
-import com.dreamypatisiel.devdevdev.domain.repository.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.web.response.ResultType;
 import jakarta.servlet.http.Cookie;
@@ -138,7 +137,8 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail), SocialType.valueOf(socialType)).get();
+        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail),
+                SocialType.valueOf(socialType)).get();
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/token/test/user")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -180,6 +180,7 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
                 ))
         );
     }
+
     @Test
     @DisplayName("ADMIN 테스트 계정의 토큰을 생성하고 해당 토큰을 응답한다.")
     void createAdminToken() throws Exception {
@@ -191,7 +192,8 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail), SocialType.valueOf(socialType)).get();
+        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail),
+                SocialType.valueOf(socialType)).get();
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/token/test/admin")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -234,7 +236,8 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
         );
     }
 
-    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email, String socialType, String role) {
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
         return SocialMemberDto.builder()
                 .userId(userId)
                 .name(name)


### PR DESCRIPTION
## 신규 가입시 닉네임 자동생성
- 회원가입 과정에 닉네임 생성 및 적용 단계 추가
```java
// 데이터베이스 회원이 없으면 회원가입 시킨다.
String encodePassword = passwordEncoder.encode(new Password().getPassword());
SocialMemberDto socialMemberDto = SocialMemberDto.from(oAuth2UserProvider, encodePassword);

// 랜덤 닉네임 생성
String randomNickname = memberNicknameDictionaryService.createRandomNickname();
socialMemberDto.setNickname(randomNickname);
```

- enum WordType 의 우선순위에 따라 랜덤으로 단어 1개씩 불러온 후 concat
   - 랜덤으로 단어 1개씩 불러오는 것은 jpql에서 rand() 함수를 사용
      - `.orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())`
   - enum WordType(부사, 형용사, 명사)의 종류나 우선순위가 달라지면 달라진 우선순위에 따라 닉네임이 생성됨
      - 현재: 부사(1) 형용사(2) 명사(3)


