### PR TITLE
[DP-177] 회원탈퇴 API

### DIFF
--- a/src/docs/asciidoc/api/mypage/delete-member.adoc
+++ b/src/docs/asciidoc/api/mypage/delete-member.adoc
@@ -3,6 +3,7 @@
 
 * 회원은 회원탈퇴를 진행할 수 있다.
 * 회원탈퇴 완료시 더이상 회원을 조회할 수 없다.
+* 회원탈퇴 완료시 리프레시 쿠키가 초기화되고, 로그인 활성화 여부 쿠키가 비활성화로 변경된다.
 
 === 정상 요청/응답
 
@@ -14,6 +15,10 @@ include::{snippets}/mypage-member-delete/http-request.adoc[]
 
 include::{snippets}/mypage-member-delete/request-headers.adoc[]
 
+==== HTTP Request Cookie Fields
+
+include::{snippets}/logout/request-cookies.adoc[]
+
 ==== HTTP Response
 
 include::{snippets}/mypage-member-delete/http-response.adoc[]
@@ -21,6 +26,9 @@ include::{snippets}/mypage-member-delete/http-response.adoc[]
 ==== HTTP Response Fields
 
 include::{snippets}/mypage-member-delete/response-fields.adoc[]
+
+==== HTTP Response Cookie Fields
+include::{snippets}/mypage-member-delete/response-cookies.adoc[]
 
 === 예외
 

--- a/src/docs/asciidoc/api/mypage/delete-member.adoc
+++ b/src/docs/asciidoc/api/mypage/delete-member.adoc
@@ -1,0 +1,29 @@
+[[DeleteMember]]
+== 회원탈퇴 API(GET: /devdevdev/api/v1/mypage/delete)
+
+* 회원은 회원탈퇴를 진행할 수 있다.
+* 회원탈퇴 완료시 더이상 회원을 조회할 수 없다.
+
+=== 정상 요청/응답
+
+==== HTTP Request
+
+include::{snippets}/mypage-member-delete/http-request.adoc[]
+
+==== HTTP Request Header Fields
+
+include::{snippets}/mypage-member-delete/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/mypage-member-delete/http-response.adoc[]
+
+==== HTTP Response Fields
+
+include::{snippets}/mypage-member-delete/response-fields.adoc[]
+
+=== 예외
+
+==== HTTP Response
+
+include::{snippets}/not-found-member-exception/response-body.adoc[]

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -140,8 +140,8 @@ public class Member extends BasicTime {
         return this.role.equals(Role.ROLE_ADMIN);
     }
 
-    public void deleteMember() {
+    public void deleteMember(LocalDateTime now) {
         this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
+        this.deletedAt = now;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -25,10 +25,14 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true, deletedAt = NOW() WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 @Table(indexes = {
         @Index(name = "idx__name__user_id", columnList = "name, userId"),
         @Index(name = "idx__email__socialType", columnList = "email, socialType")
@@ -85,6 +89,9 @@ public class Member extends BasicTime {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private Boolean isDeleted;
+    private LocalDateTime deletedAt;
+
     @OneToMany(mappedBy = "member")
     private List<InterestedCompany> interestedCompanies = new ArrayList<>();
 
@@ -109,7 +116,7 @@ public class Member extends BasicTime {
         member.password = socialMemberDto.getPassword();
         member.socialType = socialMemberDto.getSocialType();
         member.role = socialMemberDto.getRole();
-
+        member.isDeleted = false;
         return member;
     }
 
@@ -131,5 +138,10 @@ public class Member extends BasicTime {
 
     public boolean isAdmin() {
         return this.role.equals(Role.ROLE_ADMIN);
+    }
+
+    public void deleteMember() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/AnonymousMemberRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/AnonymousMemberRepository.java
@@ -1,4 +1,4 @@
-package com.dreamypatisiel.devdevdev.domain.repository;
+package com.dreamypatisiel.devdevdev.domain.repository.member;
 
 import com.dreamypatisiel.devdevdev.domain.entity.AnonymousMember;
 import java.util.Optional;

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -1,0 +1,30 @@
+package com.dreamypatisiel.devdevdev.domain.service.member;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberProvider memberProvider;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 회원 탈퇴 회원의 북마크와 회원 정보를 삭제합니다.
+     */
+    @Transactional
+    public void deleteMember(Authentication authentication) {
+        // 회원 조회
+        Member member = memberProvider.getMemberByAuthentication(authentication);
+
+        // 회원 삭제
+        member.deleteMember();
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -3,6 +3,7 @@ package com.dreamypatisiel.devdevdev.domain.service.member;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import com.dreamypatisiel.devdevdev.global.common.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class MemberService {
 
     private final MemberProvider memberProvider;
     private final MemberRepository memberRepository;
+    private final TimeProvider timeProvider;
 
     /**
      * 회원 탈퇴 회원의 북마크와 회원 정보를 삭제합니다.
@@ -25,6 +27,6 @@ public class MemberService {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         // 회원 삭제
-        member.deleteMember();
+        member.deleteMember(timeProvider.getLocalDateTimeNow());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickService.java
@@ -13,7 +13,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.PickVote;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.ContentStatus;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.AnonymousMemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.AnonymousMemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickSort;

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,14 +1,15 @@
 package com.dreamypatisiel.devdevdev.global.security.oauth2.handler;
 
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
-import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
-import com.dreamypatisiel.devdevdev.global.security.jwt.service.TokenService;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
 import com.dreamypatisiel.devdevdev.global.security.jwt.service.JwtMemberService;
+import com.dreamypatisiel.devdevdev.global.security.jwt.service.TokenService;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.OAuth2UserProvider;
+import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.global.utils.UriUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,11 +18,8 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
 /**
- * 로그인 순서(2)
- * OAuth 2.0 로그인(회원가입)이 성공하면 실행되는 핸들러
+ * 로그인 순서(2) OAuth 2.0 로그인(회원가입)이 성공하면 실행되는 핸들러
  */
 @Slf4j
 @Component
@@ -38,12 +36,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     // OAuth2.0 로그인 성공시 수행하는 로직
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
         OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
         String socialType = oauthToken.getAuthorizedClientRegistrationId().toUpperCase();
 
         // 토큰 생성
-        OAuth2UserProvider oAuth2UserProvider = OAuth2UserProvider.getOAuth2UserProvider(SocialType.valueOf(socialType), authentication);
+        OAuth2UserProvider oAuth2UserProvider = OAuth2UserProvider.getOAuth2UserProvider(SocialType.valueOf(socialType),
+                authentication);
         Token token = tokenService.generateTokenByOAuth2UserProvider(oAuth2UserProvider);
 
         // 토큰을 쿠키에 저장

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/MypageController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/MypageController.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.web.controller;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
+import com.dreamypatisiel.devdevdev.domain.service.member.MemberService;
 import com.dreamypatisiel.devdevdev.domain.service.response.TechArticleMainResponse;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleService;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleServiceStrategy;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MypageController {
 
     private final TechArticleServiceStrategy techArticleServiceStrategy;
+    private final MemberService memberService;
 
     @Operation(summary = "북마크 목록 조회")
     @GetMapping("/mypage/bookmarks")
@@ -36,8 +39,19 @@ public class MypageController {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        Slice<TechArticleMainResponse> response = techArticleService.getBookmarkedTechArticles(pageable, techArticleId, bookmarkSort, authentication);
+        Slice<TechArticleMainResponse> response = techArticleService.getBookmarkedTechArticles(pageable, techArticleId,
+                bookmarkSort, authentication);
 
         return ResponseEntity.ok(BasicResponse.success(response));
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/mypage/delete")
+    public ResponseEntity<BasicResponse<Void>> deleteMember() {
+
+        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
+        memberService.deleteMember(authentication);
+
+        return ResponseEntity.ok(BasicResponse.success());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/MypageController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/MypageController.java
@@ -5,10 +5,14 @@ import com.dreamypatisiel.devdevdev.domain.service.member.MemberService;
 import com.dreamypatisiel.devdevdev.domain.service.response.TechArticleMainResponse;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleService;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleServiceStrategy;
+import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.response.BasicResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -47,10 +51,15 @@ public class MypageController {
 
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/mypage/delete")
-    public ResponseEntity<BasicResponse<Void>> deleteMember() {
+    public ResponseEntity<BasicResponse<Void>> deleteMember(HttpServletRequest request, HttpServletResponse response) {
 
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
         memberService.deleteMember(authentication);
+
+        // 쿠키 설정
+        CookieUtils.deleteCookieFromResponse(request, response, JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN);
+        CookieUtils.addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS,
+                CookieUtils.INACTIVE, CookieUtils.DEFAULT_MAX_AGE, false, true);
 
         return ResponseEntity.ok(BasicResponse.success());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   profiles:
     active:
-      - dev
+      - local
     include:
-      - oauth2-dev
-      - jwt-dev
+      - oauth2-local
+      - jwt-local
       - storage-s3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   profiles:
     active:
-      - local
+      - dev
     include:
-      - oauth2-local
-      - jwt-local
+      - oauth2-dev
+      - jwt-dev
       - storage-s3

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
@@ -1,0 +1,111 @@
+package com.dreamypatisiel.devdevdev.domain.service.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
+import com.dreamypatisiel.devdevdev.exception.MemberException;
+import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    String userId = "dreamy5patisiel";
+    String name = "꿈빛파티시엘";
+    String nickname = "행복한 꿈빛파티시엘";
+    String email = "dreamy5patisiel@kakao.com";
+    String password = "password";
+    String socialType = SocialType.KAKAO.name();
+    String role = Role.ROLE_USER.name();
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    TechArticleRepository techArticleRepository;
+    @Autowired
+    BookmarkRepository bookmarkRepository;
+    @Autowired
+    PickRepository pickRepository;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberProvider memberProvider;
+
+    @Test
+    @DisplayName("회원이 회원탈퇴를 요청하면 해당 회원의 isDeleted가 true로 변경된다.")
+    void deleteMemberTest() {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto(userId, name, nickname, password, email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        Member savedMember = memberRepository.save(member);
+
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // when
+        memberService.deleteMember(authentication);
+
+        // then
+        assertThat(savedMember)
+                .isNotNull()
+                .extracting(Member::getIsDeleted)
+                .isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("회원이 회원탈퇴를 완료하면 더이상 회원이 조회되지 않는다.")
+    void deleteMemberNotFoundTest() {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto(userId, name, nickname, password, email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        memberRepository.save(member);
+
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // when
+        memberService.deleteMember(authentication);
+
+        // then
+        assertThatThrownBy(() -> memberProvider.getMemberByAuthentication(authentication))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+    }
+
+    private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email,
+                                            String socialType, String role) {
+        return SocialMemberDto.builder()
+                .userId(userId)
+                .name(name)
+                .nickname(nickName)
+                .password(password)
+                .email(email)
+                .socialType(SocialType.valueOf(socialType))
+                .role(Role.valueOf(role))
+                .build();
+    }
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/GuestPickServiceTest.java
@@ -25,7 +25,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.AnonymousMemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.member.AnonymousMemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -235,6 +235,49 @@ class MyPageControllerTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.data.empty").isBoolean());
     }
 
+    @Test
+    @DisplayName("회원이 회원탈퇴를 한다.")
+    void deleteMember() throws Exception {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        member.updateRefreshToken(refreshToken);
+        memberRepository.save(member);
+
+        // when // then
+        ResultActions actions = mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/delete")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding(StandardCharsets.UTF_8)
+                                .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultType").value(ResultType.SUCCESS.name()));
+    }
+
+    @Test
+    @DisplayName("회원이 회원탈퇴를 할 때 회원이 없으면 예외가 발생한다.")
+    void deleteMemberNotFound() throws Exception {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        member.updateRefreshToken(refreshToken);
+
+        // when // then
+        ResultActions actions = mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/delete")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding(StandardCharsets.UTF_8)
+                                .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultType").value(ResultType.FAIL.name()))
+                .andExpect(jsonPath("$.message").value(INVALID_MEMBER_NOT_FOUND_MESSAGE))
+                .andExpect(jsonPath("$.errorCode").value(HttpStatus.NOT_FOUND.value()));
+    }
+
     private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email,
                                             String socialType, String role) {
         return SocialMemberDto.builder()

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -2,8 +2,13 @@ package com.dreamypatisiel.devdevdev.web.docs;
 
 import static com.dreamypatisiel.devdevdev.exception.MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
+import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS;
+import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;
 import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.authenticationType;
 import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.bookmarkSortType;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -37,6 +42,7 @@ import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticle
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.web.response.ResultType;
+import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -259,11 +265,14 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
 
+        Cookie cookie = new Cookie(DEVDEVDEV_REFRESH_TOKEN, refreshToken);
+
         // when // then
         ResultActions actions = mockMvc.perform(
                         RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/delete")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .characterEncoding(StandardCharsets.UTF_8)
+                                .cookie(cookie)
                                 .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -274,7 +283,14 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestHeaders(
-                        headerWithName(AUTHORIZATION_HEADER).optional().description("Bearer 엑세스 토큰")
+                        headerWithName(AUTHORIZATION_HEADER).description("Bearer 엑세스 토큰")
+                ),
+                requestCookies(
+                        cookieWithName(DEVDEVDEV_REFRESH_TOKEN).description("리프레시 토큰")
+                ),
+                responseCookies(
+                        cookieWithName(DEVDEVDEV_REFRESH_TOKEN).description("리프레시 토큰"),
+                        cookieWithName(DEVDEVDEV_LOGIN_STATUS).description("로그인 활성화 유뮤(active | inactive)")
                 ),
                 responseFields(
                         fieldWithPath("resultType").type(JsonFieldType.STRING).description("응답 결과")


### PR DESCRIPTION
## 회원탈퇴 API
- 회원탈퇴시 해당 member 엔티티의 isDeleted가 true로 업데이트 됩니다.
- @SQLRestriction을 통해 member 엔티티 조회시 isDeleted = false를 디폴트 옵션으로 조회하도록 합니다.
   - 대부분의 엔티티가 is_deleted = false인 경우, 인덱스를 설정하면 오히려 효율성이 떨어질 수 있기 때문에 인덱스를 추가하진 않았습니다.
- @SQLDelete를 통해, 추후 member 엔티티의 Delete 쿼리가 호출되더라도 소프트삭제로 변경되도록 하였습니다.

```java
@SQLDelete(sql = "UPDATE member SET is_deleted = true, deletedAt = NOW() WHERE id = ?")
@SQLRestriction("is_deleted = false")
public class Member extends BasicTime {
   ...
}
```