### PR TITLE
[DP-193] 로그인시 회원 정보(이메일, 닉네임) 쿠키에 담아 응답

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -132,6 +132,10 @@ public class Member extends BasicTime {
         return email.getEmail();
     }
 
+    public String getNicknameAsString() {
+        return nickname.getNickname();
+    }
+
     public boolean isEqualMember(Member member) {
         return this.equals(member);
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/model/JwtCookieConstant.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/model/JwtCookieConstant.java
@@ -4,4 +4,6 @@ public class JwtCookieConstant {
     public static final String DEVDEVDEV_ACCESS_TOKEN = "DEVDEVDEV_ACCESS_TOKEN";
     public static final String DEVDEVDEV_REFRESH_TOKEN = "DEVDEVDEV_REFRESH_TOKEN";
     public static final String DEVDEVDEV_LOGIN_STATUS = "DEVDEVDEV_LOGIN_STATUS";
+    public static final String DEVDEVDEV_MEMBER_NICKNAME = "DEVDEVDEV_MEMBER_NICKNAME";
+    public static final String DEVDEVDEV_MEMBER_EMAIL = "DEVDEVDEV_MEMBER_EMAIL";
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,8 @@
 package com.dreamypatisiel.devdevdev.global.security.oauth2.handler;
 
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
+import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
 import com.dreamypatisiel.devdevdev.global.security.jwt.service.JwtMemberService;
 import com.dreamypatisiel.devdevdev.global.security.jwt.service.TokenService;
@@ -33,6 +35,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final TokenService tokenService;
     private final JwtMemberService jwtMemberService;
+    private final MemberProvider memberProvider;
 
     // OAuth2.0 로그인 성공시 수행하는 로직
     @Override
@@ -49,6 +52,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 토큰을 쿠키에 저장
         CookieUtils.configJwtCookie(response, token);
 
+        // 유저 정보 쿠키에 저장
+        Member member = memberProvider.getMemberByAuthentication(authentication);
+        CookieUtils.configMemberCookie(response, member);
+
         // 리다이렉트 설정
         String redirectUri = UriUtils.createUriByDomainAndEndpoint(domain, endpoint);
         getRedirectStrategy().sendRedirect(request, response, redirectUri);
@@ -56,5 +63,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 리프레시 토큰 저장
         jwtMemberService.updateMemberRefreshToken(token.getRefreshToken());
         log.info("OAuth2SuccessHandler accessToken={}", token.getAccessToken());
+        log.info("response={}", response.toString());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
@@ -1,11 +1,14 @@
 package com.dreamypatisiel.devdevdev.global.utils;
 
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.exception.CookieException;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import org.springframework.util.ObjectUtils;
@@ -89,6 +92,17 @@ public class CookieUtils {
                 token.getRefreshToken(), REFRESH_MAX_AGE, true, true);
         addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS,
                 ACTIVE, DEFAULT_MAX_AGE, false, true);
+    }
+
+    public static void configMemberCookie(HttpServletResponse response, Member member) {
+        // UTF-8 인코딩 필요
+        String nickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
+        String email = URLEncoder.encode(member.getEmailAsString(), StandardCharsets.UTF_8);
+
+        addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME,
+                nickname, DEFAULT_MAX_AGE, false, true);
+        addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL,
+                email, DEFAULT_MAX_AGE, false, true);
     }
 
     private static void validationCookieEmpty(Cookie[] cookies) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
@@ -95,14 +95,13 @@ public class CookieUtils {
     }
 
     public static void configMemberCookie(HttpServletResponse response, Member member) {
-        // UTF-8 인코딩 필요
+        // 닉네임 UTF-8 인코딩 필요
         String nickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
-        String email = URLEncoder.encode(member.getEmailAsString(), StandardCharsets.UTF_8);
 
         addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME,
                 nickname, DEFAULT_MAX_AGE, false, true);
         addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL,
-                email, DEFAULT_MAX_AGE, false, true);
+                member.getEmailAsString(), DEFAULT_MAX_AGE, false, true);
     }
 
     private static void validationCookieEmpty(Cookie[] cookies) {

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -80,6 +80,7 @@ class OAuth2SuccessHandlerTest {
     @Test
     @DisplayName("OAuth2.0 로그인 성공 시"
             + " 토큰을 생성하고 토큰을 쿠키에 저장하고"
+            + " 로그인된 회원의 이메일과 닉네임을 쿠키에 저장하고"
             + " 리다이렉트를 설정하고"
             + " 회원에 리프레시 토큰을 저장한다.")
     void onAuthenticationSuccess() throws IOException {
@@ -98,10 +99,16 @@ class OAuth2SuccessHandlerTest {
         Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email), socialType).get();
         Cookie accessCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_ACCESS_TOKEN);
         Cookie refreshCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN);
+        Cookie loginStatusCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS);
+        Cookie nicknameCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME);
+        Cookie emailCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL);
 
         assertAll(
                 () -> assertThat(accessCookie).isNotNull(),
-                () -> assertThat(refreshCookie).isNotNull()
+                () -> assertThat(refreshCookie).isNotNull(),
+                () -> assertThat(loginStatusCookie).isNotNull(),
+                () -> assertThat(nicknameCookie).isNotNull(),
+                () -> assertThat(emailCookie).isNotNull()
         );
         assertAll(
                 () -> assertThat(accessCookie.isHttpOnly()).isFalse(),

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
@@ -1,18 +1,24 @@
 package com.dreamypatisiel.devdevdev.global.utils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.exception.CookieException;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import jakarta.servlet.http.Cookie;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import static org.assertj.core.api.Assertions.*;
 
 class CookieUtilsTest {
 
@@ -193,7 +199,7 @@ class CookieUtilsTest {
 
     @Test
     @DisplayName("응답 정보에 JWT 관련 쿠키를 설정할 때 토큰 정보를 저장한다."
-            + " (엑세스 토큰은 secure은 false, httpOnly은 false로 저장하고"
+            + " (엑세스 토큰은 secure은 true, httpOnly은 false로 저장하고"
             + " 리프레시 토큰은 secure은 true, httpOnly은 true 저장한다.)")
     void configJwtCookie() {
         // given
@@ -241,4 +247,57 @@ class CookieUtilsTest {
         );
     }
 
+    @Test
+    @DisplayName("응답 정보에 멤버 관련 쿠키를 설정한다."
+            + " (유저 닉네임과 이메일은 UTF-8로 인코딩되고, secure은 true, httpOnly은 false로 저장한다.)")
+    void configMemberCookie() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", "email@gmail.com", SocialType.KAKAO.name(), Role.ROLE_USER.name());
+        Member member = Member.createMemberBy(socialMemberDto);
+        String encodedNickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
+        String encodedEmail = URLEncoder.encode(member.getEmailAsString(), StandardCharsets.UTF_8);
+
+        // when
+        CookieUtils.configMemberCookie(response, member);
+
+        // then
+        Cookie nicknameCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME);
+        Cookie emailCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL);
+
+        assertAll(
+                () -> assertThat(nicknameCookie).isNotNull(),
+                () -> assertThat(emailCookie).isNotNull()
+        );
+
+        assertAll(
+                () -> assertThat(nicknameCookie.getName()).isEqualTo(JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME),
+                () -> assertThat(nicknameCookie.getValue()).isEqualTo(encodedNickname),
+                () -> assertThat(nicknameCookie.getMaxAge()).isEqualTo(CookieUtils.DEFAULT_MAX_AGE),
+                () -> assertThat(nicknameCookie.getSecure()).isTrue(),
+                () -> assertThat(nicknameCookie.isHttpOnly()).isFalse()
+        );
+
+        assertAll(
+                () -> assertThat(emailCookie.getName()).isEqualTo(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL),
+                () -> assertThat(emailCookie.getValue()).isEqualTo(encodedEmail),
+                () -> assertThat(emailCookie.getMaxAge()).isEqualTo(CookieUtils.DEFAULT_MAX_AGE),
+                () -> assertThat(emailCookie.getSecure()).isTrue(),
+                () -> assertThat(emailCookie.isHttpOnly()).isFalse()
+        );
+    }
+
+    private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,
+                                            String socialType, String role) {
+        return SocialMemberDto.builder()
+                .userId(userId)
+                .name(name)
+                .nickname(nickname)
+                .password(password)
+                .email(email)
+                .socialType(SocialType.valueOf(socialType))
+                .role(Role.valueOf(role))
+                .build();
+    }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
@@ -249,7 +249,8 @@ class CookieUtilsTest {
 
     @Test
     @DisplayName("응답 정보에 멤버 관련 쿠키를 설정한다."
-            + " (유저 닉네임과 이메일은 UTF-8로 인코딩되고, secure은 true, httpOnly은 false로 저장한다.)")
+            + " (유저 닉네임은 UTF-8로 인코딩되고 이메일은 인코딩되지 않는다."
+            + " secure은 true, httpOnly은 false로 저장한다.)")
     void configMemberCookie() {
         // given
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -257,7 +258,7 @@ class CookieUtilsTest {
                 "꿈빛파티시엘", "1234", "email@gmail.com", SocialType.KAKAO.name(), Role.ROLE_USER.name());
         Member member = Member.createMemberBy(socialMemberDto);
         String encodedNickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
-        String encodedEmail = URLEncoder.encode(member.getEmailAsString(), StandardCharsets.UTF_8);
+        String email = member.getEmailAsString();
 
         // when
         CookieUtils.configMemberCookie(response, member);
@@ -281,7 +282,7 @@ class CookieUtilsTest {
 
         assertAll(
                 () -> assertThat(emailCookie.getName()).isEqualTo(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL),
-                () -> assertThat(emailCookie.getValue()).isEqualTo(encodedEmail),
+                () -> assertThat(emailCookie.getValue()).isEqualTo(email),
                 () -> assertThat(emailCookie.getMaxAge()).isEqualTo(CookieUtils.DEFAULT_MAX_AGE),
                 () -> assertThat(emailCookie.getSecure()).isTrue(),
                 () -> assertThat(emailCookie.isHttpOnly()).isFalse()


### PR DESCRIPTION
## 주요 변경사항
- OAuth2 로그인 성공시 쿠키에 `DEVDEVDEV_MEMBER_EMAIL`, `DEVDEVDEV_MEMBER_NICKNAME` 을 담아 응답합니다.
   - 각 회원 정보 쿠키의 유효기간은 AccessToken과 동일합니다.
- 쿠키는 콤마(,) 세미콜론(:) 공백문자( ) 를 제외하고는 모두 ASCII 코드로 구성되기 때문에 한글 사용이 불가능하므로, 닉네임은 UTF8 인코딩 과정을 거친 후 쿠키에 저장됩니다.