### PR TITLE
[DP-210] 픽픽픽/기술블로그 페이지네이션 에러 수정 & 픽픽픽 옵션 내용 null 가능하도록 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/PickOption.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/PickOption.java
@@ -132,4 +132,13 @@ public class PickOption extends BasicTime {
     public void minusVoteTotalCount() {
         this.voteTotalCount = Count.minusOne(this.voteTotalCount);
     }
+
+    public String getContentsAsString() {
+        String pickOptionContents = contents.getPickOptionContents();
+        if (pickOptionContents == null) {
+            return "";
+        }
+
+        return pickOptionContents;
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/custom/PickRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/custom/PickRepositoryImpl.java
@@ -36,7 +36,7 @@ public class PickRepositoryImpl implements PickRepositoryCustom {
     @Override
     public Slice<Pick> findPicksByCursor(Pageable pageable, Long pickId, PickSort pickSort) {
         // 1개의 pick에 2개의 pickOtion이 존재하기 때문에 pageSize에 2를 곱해야 한다.
-        long limit = pageable.getPageSize() * TWO + ONE;
+        long limit = pageable.getPageSize() * TWO;
 
         List<Pick> contents = query.selectFrom(pick)
                 .leftJoin(pick.pickOptions, pickOption)
@@ -56,7 +56,7 @@ public class PickRepositoryImpl implements PickRepositoryCustom {
     @Override
     public Slice<Pick> findPicksByMemberAndCursor(Pageable pageable, Member member, Long pickId) {
         // 1개의 pick에 2개의 pickOtion이 존재하기 때문에 pageSize에 2를 곱해야 한다.
-        long limit = pageable.getPageSize() * TWO + ONE;
+        long limit = pageable.getPageSize() * TWO;
 
         List<Pick> contents = query.selectFrom(pick)
                 .leftJoin(pick.pickOptions, pickOption)
@@ -124,6 +124,6 @@ public class PickRepositoryImpl implements PickRepositoryCustom {
     }
 
     private boolean hasNextPage(List<Pick> contents, int pageSize) {
-        return contents.size() > pageSize;
+        return contents.size() >= pageSize;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
@@ -90,6 +90,6 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     }
 
     private boolean hasNextPage(List<TechArticle> contents, int pageSize) {
-        return contents.size() > pageSize;
+        return contents.size() >= pageSize;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickDetailOptionResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/PickDetailOptionResponse.java
@@ -41,7 +41,7 @@ public class PickDetailOptionResponse {
                 .isPicked(PickResponseUtils.isPickedPickOptionByMember(findPick, pickOption, member))
                 .percent(PickOption.calculatePercentBy(findPick, pickOption))
                 .voteTotalCount(pickOption.getVoteTotalCount().getCount())
-                .content(pickOption.getContents().getPickOptionContents())
+                .content(pickOption.getContentsAsString())
                 .pickDetailOptionImagesResponse(mapToPickDetailOptionImagesResponse(pickOption))
                 .build();
     }
@@ -54,7 +54,7 @@ public class PickDetailOptionResponse {
                 .isPicked(PickResponseUtils.isPickedPickOptionByAnonymousMember(findPick, pickOption, anonymousMember))
                 .percent(PickOption.calculatePercentBy(findPick, pickOption))
                 .voteTotalCount(pickOption.getVoteTotalCount().getCount())
-                .content(pickOption.getContents().getPickOptionContents())
+                .content(pickOption.getContentsAsString())
                 .pickDetailOptionImagesResponse(mapToPickDetailOptionImagesResponse(pickOption))
                 .build();
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/embedded/PickOptionContentsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/embedded/PickOptionContentsTest.java
@@ -2,6 +2,7 @@ package com.dreamypatisiel.devdevdev.domain.entity.embedded;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.dreamypatisiel.devdevdev.exception.TopicContentsException;
 import java.util.ArrayList;
@@ -10,6 +11,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 
@@ -18,21 +20,35 @@ class PickOptionContentsTest {
     @ParameterizedTest
     @NullSource
     @MethodSource("generateValidData")
-    @DisplayName(PickOptionContents.MAX_PICK_CONTENTS_LENGTH+" 길이의 토픽 내용을 생성할 수 있다.")
-    void topicContents(String topicContents) {
+    @DisplayName(PickOptionContents.MAX_PICK_CONTENTS_LENGTH + " 길이의 토픽 내용을 생성할 수 있다.")
+    void pickOptionContents(String pickOptionContents) {
         // given // when // then
-        assertThatCode(() -> new PickOptionContents(topicContents))
+        assertThatCode(() -> new PickOptionContents(pickOptionContents))
                 .doesNotThrowAnyException();
     }
 
     @ParameterizedTest
     @MethodSource("generateInvalidData")
-    @DisplayName(PickOptionContents.MAX_PICK_CONTENTS_LENGTH+" 길이가 아닌 토픽 내용을 생성할 경우 예외가 발생한다.")
-    void topicContentsException(String topicContents) {
+    @DisplayName(PickOptionContents.MAX_PICK_CONTENTS_LENGTH + " 길이가 아닌 토픽 내용을 생성할 경우 예외가 발생한다.")
+    void tpickOptionContentsException(String pickOptionContents) {
         // given // when // then
-        assertThatThrownBy(() -> new PickOptionContents(topicContents))
+        assertThatThrownBy(() -> new PickOptionContents(pickOptionContents))
                 .isInstanceOf(TopicContentsException.class)
                 .hasMessage(PickOptionContents.getInvalidLengthExceptionMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {":", "내용입니다.:내용입니다."}, delimiter = ':')
+    @DisplayName("픽옵션 content를 String으로 반환한다. null일 경우 빈문자열을 반환한다.")
+    void getContentsAsString(String contents, String result) {
+        // given
+        PickOptionContents pickOptionContents = new PickOptionContents(contents);
+
+        // when
+        String pickOptionContentsString = pickOptionContents.getPickOptionContents();
+
+        // then
+        assertEquals(result, pickOptionContentsString);
     }
 
     static Stream<Arguments> generateValidData() {
@@ -45,7 +61,7 @@ class PickOptionContentsTest {
     }
 
     static Stream<Arguments> generateInvalidData() {
-        int[] dataLengths = {PickOptionContents.MAX_PICK_CONTENTS_LENGTH +1};
+        int[] dataLengths = {PickOptionContents.MAX_PICK_CONTENTS_LENGTH + 1};
         List<String> data = new ArrayList<>();
         for (int i = 0; i < dataLengths.length; i++) {
             data.add(createStringBy(dataLengths[i]));

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
@@ -70,7 +70,7 @@ class TechArticleControllerTest extends SupportControllerTest {
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
         for (int i = 1; i <= 20; i++) {
             ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId_" + i, "타이틀" + i,
-                    createRandomDate(), "내용",
+                    i > 1 ? createRandomDate() : LocalDate.of(2024, 3, 11), "내용",
                     "http://example.com/" + i, "설명", "http://example.com/", "작성자", "DP", 1L, (long) i, (long) i,
                     (long) i,
                     (long) i * 10);
@@ -102,11 +102,8 @@ class TechArticleControllerTest extends SupportControllerTest {
     @DisplayName("익명 사용자가 기술블로그 메인을 조회한다.")
     void getTechArticlesByAnonymous() throws Exception {
         // given
-        Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
-        List<ElasticTechArticle> elasticTechArticles = elasticTechArticleRepository.findAll(prevPageable).stream()
-                .toList();
-        ElasticTechArticle cursor = elasticTechArticles.getLast();
+        String elasticId = "elasticId_1";
         String keyword = "타이틀";
         String companyId = "1";
 
@@ -115,7 +112,7 @@ class TechArticleControllerTest extends SupportControllerTest {
                         .queryParam("size", String.valueOf(pageable.getPageSize()))
                         .queryParam("techArticleSort", TechArticleSort.LATEST.name())
                         .queryParam("keyword", keyword)
-                        .queryParam("elasticId", cursor.getId())
+                        .queryParam("elasticId", elasticId)
                         .queryParam("companyId", companyId)
                         .queryParam("score", "10")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -183,11 +180,8 @@ class TechArticleControllerTest extends SupportControllerTest {
         }
         bookmarkRepository.saveAll(bookmarks);
 
-        Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
-        List<ElasticTechArticle> elasticTechArticles = elasticTechArticleRepository.findAll(prevPageable).stream()
-                .toList();
-        ElasticTechArticle cursor = elasticTechArticles.getLast();
+        String elasticId = "elasticId_1";
         String keyword = "타이틀";
         String companyId = "1";
 
@@ -196,7 +190,7 @@ class TechArticleControllerTest extends SupportControllerTest {
                         .queryParam("size", String.valueOf(pageable.getPageSize()))
                         .queryParam("techArticleSort", TechArticleSort.LATEST.name())
                         .queryParam("keyword", keyword)
-                        .queryParam("elasticId", cursor.getId())
+                        .queryParam("elasticId", elasticId)
                         .queryParam("companyId", companyId)
                         .queryParam("score", "10")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -82,9 +82,9 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                       @Autowired ElasticTechArticleRepository elasticTechArticleRepository) {
 
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
-        for (int i = 1; i <= 1; i++) {
+        for (int i = 1; i <= 10; i++) {
             ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId_" + i, "타이틀" + i,
-                    createRandomDate(), "내용",
+                    i > 1 ? createRandomDate() : LocalDate.of(2024, 3, 11), "내용",
                     "http://example.com/" + i, "설명", "http://example.com/", "작성자", "회사", 1L, (long) i, (long) i,
                     (long) i,
                     (long) i * 10);
@@ -131,11 +131,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         }
         bookmarkRepository.saveAll(bookmarks);
 
-        Pageable prevPageable = PageRequest.of(0, 10);
-        Pageable pageable = PageRequest.of(0, 10);
-        List<ElasticTechArticle> elasticTechArticles = elasticTechArticleRepository.findAll(prevPageable).stream()
-                .toList();
-        ElasticTechArticle cursor = elasticTechArticles.getLast();
+        Pageable pageable = PageRequest.of(0, 1);
+        String elasticId = "elasticId_1";
         String keyword = "타이틀";
         String companyId = "1";
 
@@ -144,7 +141,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         .queryParam("size", String.valueOf(pageable.getPageSize()))
                         .queryParam("techArticleSort", TechArticleSort.HIGHEST_SCORE.name())
                         .queryParam("keyword", keyword)
-                        .queryParam("elasticId", cursor.getId())
+                        .queryParam("elasticId", elasticId)
                         .queryParam("companyId", companyId)
                         .queryParam("score", "10")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -239,7 +236,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
     @DisplayName("기술블로그 메인을 조회할 때 존재하지 않는 엘라스틱서치 ID를 조회하면 에러가 발생한다.")
     void getTechArticlesNotFoundElasticIdException() throws Exception {
         // given
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, 1);
 
         // when // then
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles")
@@ -267,18 +264,15 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
             "정확도 내림차순으로 조회하기 위한 점수가 없다면 예외가 발생한다.")
     void getTechArticlesWithKeywordWithCursorOrderByHIGHEST_SCOREWithoutScoreException() throws Exception {
         // given
-        Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
-        List<ElasticTechArticle> elasticTechArticles = elasticTechArticleRepository.findAll(prevPageable).stream()
-                .toList();
-        ElasticTechArticle cursor = elasticTechArticles.getLast();
+        String elasticId = "elasticId_1";
         String keyword = "타이틀";
 
         // when // then
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/articles")
                         .queryParam("size", String.valueOf(pageable.getPageSize()))
                         .queryParam("techArticleSort", TechArticleSort.HIGHEST_SCORE.name())
-                        .queryParam("elasticId", cursor.getId())
+                        .queryParam("elasticId", elasticId)
                         .queryParam("keyword", keyword)
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8))


### PR DESCRIPTION
# 픽픽픽/기술블로그 페이지네이션 에러 수정
- 픽픽픽 메인 조회시 요청 size의 +1의 크기로 응답 보내던 것 수정(limit 값 수정)
```java
// before
long limit = pageable.getPageSize() * TWO + ONE;

// after
long limit = pageable.getPageSize() * TWO;
```
- 픽픽픽/기술블로그 조회시 last 로직 에러 수정
```java
// before
private boolean hasNextPage(List<Pick> contents, int pageSize) {
    return contents.size() > pageSize;

// after
private boolean hasNextPage(List<Pick> contents, int pageSize) {
    return contents.size() >= pageSize; // 등호 추가
}
```

# 픽픽픽 옵션 내용 null 가능하도록 수정
- PickOptionContents가 null일 경우 "" 빈문자열 응답하도록 수정
```java
public String getContentsAsString() {
    String pickOptionContents = contents.getPickOptionContents();
    if (pickOptionContents == null) {
        return "";
    }

    return pickOptionContents;
}
```