### PR TITLE
[DP-219] 검색 키워드에 특수문자가 있을 경우 예외 발생

### DIFF
--- a/src/docs/asciidoc/api/tech-article/main.adoc
+++ b/src/docs/asciidoc/api/tech-article/main.adoc
@@ -1,25 +1,39 @@
 [[TechArticleMain]]
 == 기술블로그 메인 API(GET: /devdevdev/api/v1/articles)
+
 * 기술블로그 메인 화면을 조회하거나 검색할 수 있다.
 * 회원/익명 사용자에 따라 API 응답값이 상이하다.
 
 === 정상 요청/응답
+
 ==== HTTP Request
+
 include::{snippets}/tech-article-main/http-request.adoc[]
+
 ==== HTTP Request Header Fields
+
 include::{snippets}/tech-article-main/request-headers.adoc[]
+
 ==== HTTP Request Query Parameters Fields
+
 include::{snippets}/tech-article-main/query-parameters.adoc[]
 
 ==== HTTP Response
+
 include::{snippets}/tech-article-main/http-response.adoc[]
+
 ==== HTTP Response Fields
+
 include::{snippets}/tech-article-main/response-fields.adoc[]
 
-
 === 예외
+
 ==== HTTP Response
+
 include::{snippets}/not-found-elastic-tech-article-cursor-exception/response-body.adoc[]
 include::{snippets}/not-found-score-exception/response-body.adoc[]
+include::{snippets}/keyword-with-special-symbols-exception/response-body.adoc[]
+
 ==== HTTP Response Fields
+
 include::{snippets}/not-found-score-exception/response-fields.adoc[]

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/TechArticleExceptionMessage.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/TechArticleExceptionMessage.java
@@ -6,4 +6,5 @@ public class TechArticleExceptionMessage {
     public static final String NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE = "존재하지 않는 기술블로그입니다.";
     public static final String INVALID_ELASTIC_METHODS_CALL_MESSAGE = "검색어가 없습니다. 검색어를 입력해주세요.";
     public static final String NOT_FOUND_CURSOR_SCORE_MESSAGE = "정확도순 페이지네이션을 위한 커서의 score를 입력해주세요.";
+    public static final String KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE = "검색어에 특수문자는 포함할 수 없어요";
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
@@ -77,7 +78,8 @@ public class ElasticTechArticleService implements ElasticService<ElasticTechArti
     private List<ElasticResponse<ElasticTechArticle>> searchTechArticles(Pageable pageable, String elasticId,
                                                                          TechArticleSort techArticleSort,
                                                                          String keyword,
-                                                                         Long companyId, Float score) {
+                                                                         Long companyId, Float score)
+            throws UncategorizedElasticsearchException {
 
         // 검색어 유무 확인
         if (!StringUtils.hasText(keyword)) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/exception/ApiControllerAdvice.java
@@ -1,10 +1,16 @@
 package com.dreamypatisiel.devdevdev.web.controller.exception;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE;
 import static com.dreamypatisiel.devdevdev.web.controller.exception.SystemErrorConstant.EXTERNAL_SYSTEM_ERROR_MESSAGE;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
-import com.dreamypatisiel.devdevdev.exception.*;
+import com.dreamypatisiel.devdevdev.exception.ImageFileException;
+import com.dreamypatisiel.devdevdev.exception.MemberException;
+import com.dreamypatisiel.devdevdev.exception.NotFoundException;
+import com.dreamypatisiel.devdevdev.exception.PickOptionImageNameException;
+import com.dreamypatisiel.devdevdev.exception.TokenInvalidException;
+import com.dreamypatisiel.devdevdev.exception.TokenNotFoundException;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.response.BasicResponse;
@@ -13,11 +19,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -41,11 +47,21 @@ public class ApiControllerAdvice {
                 HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(UncategorizedElasticsearchException.class)
+    public ResponseEntity<BasicResponse<Object>> uncategorizedElasticsearchException(
+            UncategorizedElasticsearchException e) {
+        log.debug("UncategorizedElasticsearchException={}", e.getMessage(), e);
+        return new ResponseEntity<>(
+                BasicResponse.fail(KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE, HttpStatus.BAD_REQUEST.value()),
+                HttpStatus.BAD_REQUEST);
+    }
+    
     // 요청을 하거나 응답을 처리하는 동안 클라이언트에서 오류가 발생한 경우.
     @ExceptionHandler(SdkClientException.class)
     public ResponseEntity<BasicResponse<Object>> sdkClientException(SdkClientException e) {
         log.error("sdkClientException={}", e.getMessage(), e);
-        return new ResponseEntity<>(BasicResponse.fail(EXTERNAL_SYSTEM_ERROR_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE.value()),
+        return new ResponseEntity<>(
+                BasicResponse.fail(EXTERNAL_SYSTEM_ERROR_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE.value()),
                 HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -53,7 +69,8 @@ public class ApiControllerAdvice {
     @ExceptionHandler(AmazonServiceException.class)
     public ResponseEntity<BasicResponse<Object>> amazonServiceException(AmazonServiceException e) {
         log.error("amazonServiceException={}", e.getMessage(), e);
-        return new ResponseEntity<>(BasicResponse.fail(EXTERNAL_SYSTEM_ERROR_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE.value()),
+        return new ResponseEntity<>(
+                BasicResponse.fail(EXTERNAL_SYSTEM_ERROR_MESSAGE, HttpStatus.SERVICE_UNAVAILABLE.value()),
                 HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -101,7 +118,9 @@ public class ApiControllerAdvice {
     }
 
     @ExceptionHandler(TokenInvalidException.class)
-    public ResponseEntity<BasicResponse<Object>> tokenInvalidException(HttpServletRequest request, HttpServletResponse response, TokenInvalidException e)
+    public ResponseEntity<BasicResponse<Object>> tokenInvalidException(HttpServletRequest request,
+                                                                       HttpServletResponse response,
+                                                                       TokenInvalidException e)
             throws ServletException {
         request.logout(); // 로그아웃 처리
         CookieUtils.deleteCookieFromResponse(request, response, JwtCookieConstant.DEVDEVDEV_ACCESS_TOKEN);

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.web.controller;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
@@ -285,6 +286,28 @@ class TechArticleControllerTest extends SupportControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.resultType").value(ResultType.FAIL.name()))
                 .andExpect(jsonPath("$.message").value(NOT_FOUND_CURSOR_SCORE_MESSAGE))
+                .andExpect(jsonPath("$.errorCode").value(HttpStatus.BAD_REQUEST.value()));
+    }
+
+
+    @Test
+    @DisplayName("기술블로그 메인을 조회할 때 키워드에 특수문자가 있다면 에러가 발생한다.")
+    void getTechArticlesSpecialSymbolException() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        String keyword = "!";
+
+        // when // then
+        mockMvc.perform(get("/devdevdev/api/v1/articles")
+                        .queryParam("size", String.valueOf(pageable.getPageSize()))
+                        .queryParam("techArticleSort", TechArticleSort.LATEST.name())
+                        .queryParam("keyword", keyword)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultType").value(ResultType.FAIL.name()))
+                .andExpect(jsonPath("$.message").value(KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE))
                 .andExpect(jsonPath("$.errorCode").value(HttpStatus.BAD_REQUEST.value()));
     }
 


### PR DESCRIPTION
### 검색 불가 특수문자가 검색어에 포함된 경우 예외가 발생합니다
- 검색 불가 특수문자 ! ^ ( ) - + / [ ] { } :
- 검색 가능 특수문자 @ = # $ % & * _ = < > , . ? ;  '

```java
{
  "resultType" : "FAIL",
  "message" : "검색어에 특수문자는 포함할 수 없어요",
  "errorCode" : 400
}
```