### PR TITLE
[DP-227] 기술블로그 조회 총 개수 이슈 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -53,13 +54,15 @@ public class GuestTechArticleService extends TechArticleCommonService implements
         AuthenticationMemberUtils.validateAnonymousMethodCall(authentication);
 
         // 엘라스틱서치 기술블로그 조회
-        List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> elasticTechArticleSearchHits = elasticTechArticleService.getTechArticles(
                 pageable, elasticId, techArticleSort, keyword, companyId, score);
+        List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.mapToElasticResponse(
+                elasticTechArticleSearchHits);
 
         // 데이터 가공
         List<TechArticleMainResponse> techArticlesResponse = getTechArticlesResponse(elasticTechArticles);
 
-        return new ElasticSlice<>(techArticlesResponse, pageable, techArticlesResponse.size(),
+        return new ElasticSlice<>(techArticlesResponse, pageable, elasticTechArticleSearchHits.getTotalHits(),
                 hasNextPage(techArticlesResponse, pageable));
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleService.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,14 +63,15 @@ public class MemberTechArticleService extends TechArticleCommonService implement
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         // 엘라스틱서치 기술블로그 조회
-        List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.getTechArticles(
-                pageable, elasticId,
-                techArticleSort, keyword, companyId, score);
+        SearchHits<ElasticTechArticle> elasticTechArticleSearchHits = elasticTechArticleService.getTechArticles(
+                pageable, elasticId, techArticleSort, keyword, companyId, score);
+        List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.mapToElasticResponse(
+                elasticTechArticleSearchHits);
 
         // 데이터 가공
         List<TechArticleMainResponse> techArticlesResponse = getTechArticlesResponse(elasticTechArticles, member);
 
-        return new ElasticSlice<>(techArticlesResponse, pageable, techArticlesResponse.size(),
+        return new ElasticSlice<>(techArticlesResponse, pageable, elasticTechArticleSearchHits.getTotalHits(),
                 hasNextPage(techArticlesResponse, pageable));
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/data/domain/ElasticSlice.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/data/domain/ElasticSlice.java
@@ -7,9 +7,9 @@ import org.springframework.data.domain.SliceImpl;
 
 @Getter
 public class ElasticSlice<T> extends SliceImpl<T> {
-    private final int totalElements;
+    private final long totalElements;
 
-    public ElasticSlice(List<T> content, Pageable pageable, int totalElements, boolean hasNext) {
+    public ElasticSlice(List<T> content, Pageable pageable, long totalElements, boolean hasNext) {
         super(content, pageable, hasNext);
         this.totalElements = totalElements;
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleService.java
@@ -7,7 +7,6 @@ import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstan
 import static com.dreamypatisiel.devdevdev.elastic.constant.ElasticsearchConstant._ID;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
-import com.dreamypatisiel.devdevdev.elastic.data.domain.ElasticResponse;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.exception.ElasticTechArticleException;
@@ -25,6 +24,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.stereotype.Service;
@@ -39,9 +39,9 @@ public class ElasticTechArticleService implements ElasticService<ElasticTechArti
     private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticTechArticleRepository elasticTechArticleRepository;
 
-    public List<ElasticResponse<ElasticTechArticle>> getTechArticles(Pageable pageable, String elasticId,
-                                                                     TechArticleSort techArticleSort, String keyword,
-                                                                     Long companyId, Float score) {
+    public SearchHits<ElasticTechArticle> getTechArticles(Pageable pageable, String elasticId,
+                                                          TechArticleSort techArticleSort, String keyword,
+                                                          Long companyId, Float score) {
         if (!StringUtils.hasText(keyword)) {
             return findTechArticles(pageable, elasticId, techArticleSort, companyId);
         }
@@ -50,9 +50,9 @@ public class ElasticTechArticleService implements ElasticService<ElasticTechArti
 
     }
 
-    private List<ElasticResponse<ElasticTechArticle>> findTechArticles(Pageable pageable, String elasticId,
-                                                                       TechArticleSort techArticleSort,
-                                                                       Long companyId) {
+    private SearchHits<ElasticTechArticle> findTechArticles(Pageable pageable, String elasticId,
+                                                            TechArticleSort techArticleSort,
+                                                            Long companyId) {
         // 정렬 기준 검증
         techArticleSort = getValidSort(techArticleSort);
 
@@ -72,13 +72,13 @@ public class ElasticTechArticleService implements ElasticService<ElasticTechArti
         // searchAfter 설정
         setSearchAfterCondition(elasticId, techArticleSort, searchQuery);
 
-        return mapToElasticResponse(elasticsearchOperations.search(searchQuery, ElasticTechArticle.class));
+        return elasticsearchOperations.search(searchQuery, ElasticTechArticle.class);
     }
 
-    private List<ElasticResponse<ElasticTechArticle>> searchTechArticles(Pageable pageable, String elasticId,
-                                                                         TechArticleSort techArticleSort,
-                                                                         String keyword,
-                                                                         Long companyId, Float score)
+    private SearchHits<ElasticTechArticle> searchTechArticles(Pageable pageable, String elasticId,
+                                                              TechArticleSort techArticleSort,
+                                                              String keyword,
+                                                              Long companyId, Float score)
             throws UncategorizedElasticsearchException {
 
         // 검색어 유무 확인
@@ -107,7 +107,7 @@ public class ElasticTechArticleService implements ElasticService<ElasticTechArti
         // searchAfter 설정
         setSearchAfterConditionWhenSearch(elasticId, score, techArticleSort, searchQuery);
 
-        return mapToElasticResponse(elasticsearchOperations.search(searchQuery, ElasticTechArticle.class));
+        return elasticsearchOperations.search(searchQuery, ElasticTechArticle.class);
     }
 
     private static void setFilterWithCompanyId(Long companyId, NativeSearchQueryBuilder queryBuilder) {

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticTechArticleServiceTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
-import com.dreamypatisiel.devdevdev.elastic.data.domain.ElasticResponse;
 import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.exception.ElasticTechArticleException;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
@@ -22,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 
 public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
 
@@ -37,11 +38,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null, null,
                 null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -58,11 +58,11 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.LATEST, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -79,11 +79,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_VIEWED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -100,11 +99,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_COMMENTED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -121,11 +119,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.POPULAR, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -142,11 +139,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.HIGHEST_SCORE, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -177,19 +173,19 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.LATEST, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.LATEST, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -207,19 +203,19 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.MOST_VIEWED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.MOST_VIEWED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -237,19 +233,19 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.MOST_COMMENTED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.MOST_COMMENTED, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -267,19 +263,19 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.POPULAR, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.POPULAR, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -297,19 +293,19 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable prevPageable = PageRequest.of(0, 1);
         Pageable pageable = PageRequest.of(0, 10);
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.HIGHEST_SCORE, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.HIGHEST_SCORE, null, null, null);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -328,15 +324,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null, null,
                 keyword, null, null);
-        List<Float> elasticTechArticlesScores = techArticles.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticlesScores = techArticles.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticlesScores)
@@ -351,15 +346,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.HIGHEST_SCORE, keyword, null, null);
-        List<Float> elasticTechArticlesScores = techArticles.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticlesScores = techArticles.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticlesScores)
@@ -374,15 +368,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.LATEST, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles)
@@ -398,15 +391,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_VIEWED, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles)
@@ -422,15 +414,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_COMMENTED, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles)
@@ -446,15 +437,14 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         String keyword = "타이틀";
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.POPULAR, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles.size())
+        assertThat(techArticles.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles)
@@ -470,27 +460,25 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.HIGHEST_SCORE, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
-        List<Float> elasticTechArticleScores1 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores1 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.HIGHEST_SCORE, keyword, null, cursorScore);
-        List<Float> elasticTechArticleScores2 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores2 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
 
         // then
-        assertThat(techArticles2.size())
+        assertThat(techArticles2.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticleScores2)
@@ -506,11 +494,11 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.HIGHEST_SCORE, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
 
@@ -530,27 +518,26 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.LATEST, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
-        List<Float> elasticTechArticleScores1 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores1 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.LATEST, keyword, null, cursorScore);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles2.size())
+        assertThat(techArticles2.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles2)
@@ -568,27 +555,26 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.MOST_VIEWED, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
-        List<Float> elasticTechArticleScores1 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores1 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.MOST_VIEWED, keyword, null, cursorScore);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles2.size())
+        assertThat(techArticles2.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles2)
@@ -605,27 +591,26 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.MOST_COMMENTED, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
-        List<Float> elasticTechArticleScores1 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores1 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.MOST_COMMENTED, keyword, null, cursorScore);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles2.size())
+        assertThat(techArticles2.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles2)
@@ -642,27 +627,26 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
         String keyword = "타이틀";
 
-        List<ElasticResponse<ElasticTechArticle>> techArticles1 = elasticTechArticleService.getTechArticles(
+        SearchHits<ElasticTechArticle> techArticles1 = elasticTechArticleService.getTechArticles(
                 prevPageable, null,
                 TechArticleSort.POPULAR, keyword, null, null);
-        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles1 = techArticles1.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
-        List<Float> elasticTechArticleScores1 = techArticles1.stream()
-                .map(ElasticResponse::score)
+        List<Float> elasticTechArticleScores1 = techArticles1.getSearchHits().stream().map(SearchHit::getScore)
                 .toList();
         ElasticTechArticle cursor = elasticTechArticles1.getLast();
         Float cursorScore = elasticTechArticleScores1.getLast();
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles2 = elasticTechArticleService.getTechArticles(pageable,
                 cursor.getId(), TechArticleSort.POPULAR, keyword, null, cursorScore);
-        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles2 = techArticles2.getSearchHits().stream()
+                .map(SearchHit::getContent)
                 .toList();
 
         // then
-        assertThat(techArticles2.size())
+        assertThat(techArticles2.getSearchHits().size())
                 .isEqualTo(pageable.getPageSize());
 
         assertThat(elasticTechArticles2)
@@ -678,11 +662,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.LATEST, null, COMPANY_ID, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -702,11 +685,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_VIEWED, null, COMPANY_ID, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -726,11 +708,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.MOST_COMMENTED, null, COMPANY_ID, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then
@@ -750,11 +731,10 @@ public class ElasticTechArticleServiceTest extends ElasticsearchSupportTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        List<ElasticResponse<ElasticTechArticle>> techArticles = elasticTechArticleService.getTechArticles(pageable,
+        SearchHits<ElasticTechArticle> techArticles = elasticTechArticleService.getTechArticles(pageable,
                 null,
                 TechArticleSort.POPULAR, null, COMPANY_ID, null);
-        List<ElasticTechArticle> elasticTechArticles = techArticles.stream()
-                .map(ElasticResponse::content)
+        List<ElasticTechArticle> elasticTechArticles = techArticles.getSearchHits().stream().map(SearchHit::getContent)
                 .toList();
 
         // then


### PR DESCRIPTION
## 주요 변경사항
- ElasticTechArticleService의 getTechArticles(..) 응답타입을 `List<ElasticResponse<ElasticTechArticle>>` → `SearchHits<ElasticTechArticle>`으로 변경하였습니다.
   - ElasticTechArticleService 내부에서 가공하여 리턴하지 않고, Guest/MemberTechArticleService에서 SearchHits 전체를 응답받은 후 이 응답값을 가공하여 사용합니다. (리팩토링 이전 버전과 동일)

Before:
```java
  // 엘라스틱서치 기술블로그 조회
  List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.getTechArticles(
          pageable, elasticId, techArticleSort, keyword, companyId, score);
```

After:
```java
  // 엘라스틱서치 기술블로그 조회
  SearchHits<ElasticTechArticle> elasticTechArticleSearchHits = elasticTechArticleService.getTechArticles(
          pageable, elasticId, techArticleSort, keyword, companyId, score);
  List<ElasticResponse<ElasticTechArticle>> elasticTechArticles = elasticTechArticleService.mapToElasticResponse(
          elasticTechArticleSearchHits);
```

