### PR TITLE
[DP-244] 내작픽 수정 & 탈퇴회원 조회 관련 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -27,13 +27,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true, deletedAt = NOW() WHERE id = ?")
-@SQLRestriction("is_deleted = false")
+//@SQLRestriction("is_deleted = false")
 @Table(indexes = {
         @Index(name = "idx__name__user_id", columnList = "name, userId"),
         @Index(name = "idx__email__socialType", columnList = "email, socialType")
@@ -50,7 +49,7 @@ public class Member extends BasicTime {
             column = @Column(name = "nickname")
     )
     private Nickname nickname;
-    
+
     @Embedded
     @AttributeOverride(name = "email",
             column = @Column(name = "email")

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/MemberRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/member/MemberRepository.java
@@ -12,7 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findMembersByUserIdAndSocialType(String userId, SocialType socialType);
 
-    Optional<Member> findMemberByEmailAndSocialType(Email email, SocialType socialType);
+    Optional<Member> findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(Email email, SocialType socialType);
 
     Optional<Member> findMemberByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/PickResponseUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/PickResponseUtils.java
@@ -22,7 +22,7 @@ public class PickResponseUtils {
     public static boolean isPickedPickOptionByMember(Pick pick, PickOption pickOption,
                                                      Member member) {
         return pick.getPickVotes().stream()
-                .filter(pickVote -> pickVote.getPickOption().isEqualsPickOption(pickOption)
+                .filter(pickVote -> pickVote.getPickOption().isEqualsId(pickOption.getId())
                         && pickVote.isMemberNotNull())
                 .anyMatch(pickVote -> pickVote.getMember().isEqualMember(member));
     }
@@ -30,7 +30,7 @@ public class PickResponseUtils {
     public static boolean isPickedPickOptionByAnonymousMember(Pick pick, PickOption pickOption,
                                                               AnonymousMember anonymousMember) {
         return pick.getPickVotes().stream()
-                .filter(pickVote -> pickVote.getPickOption().isEqualsPickOption(pickOption)
+                .filter(pickVote -> pickVote.getPickOption().isEqualsId(pickOption.getId())
                         && pickVote.isAnonymousMemberNotNull())
                 .anyMatch(pickVote -> pickVote.getAnonymousMember().isEqualAnonymousMember(anonymousMember));
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
@@ -1,8 +1,8 @@
 package com.dreamypatisiel.devdevdev.global.common;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
-import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
+import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
@@ -32,7 +32,7 @@ public class MemberProvider {
         String email = userPrincipal.getEmail();
         SocialType socialType = userPrincipal.getSocialType();
 
-        return memberRepository.findMemberByEmailAndSocialType(new Email(email), socialType)
+        return memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email), socialType)
                 .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
@@ -38,7 +38,7 @@ public class JwtMemberService {
         String socialType = tokenService.getSocialType(refreshToken);
 
         // 회원 조회
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                         SocialType.valueOf(socialType))
                 .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
 
@@ -67,7 +67,7 @@ public class JwtMemberService {
         String socialType = claims.get(JwtClaimConstant.socialType).toString();
 
         // 회원 조회
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                         SocialType.valueOf(socialType))
                 .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
         // 리프레시 토큰 갱신
@@ -79,7 +79,8 @@ public class JwtMemberService {
         String email = userPrincipal.getEmail();
         SocialType socialType = userPrincipal.getSocialType();
 
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email), socialType)
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
+                        socialType)
                 .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
 
         findMember.updateRefreshToken(Token.DISABLED);

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
@@ -44,7 +44,7 @@ public class OAuth2MemberService {
     }
 
     private Optional<Member> findMemberByOAuth2UserProvider(OAuth2UserProvider oAuth2UserProvider) {
-        return memberRepository.findMemberByEmailAndSocialType(
+        return memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(
                 new Email(oAuth2UserProvider.getEmail()), oAuth2UserProvider.getSocialType()
         );
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
@@ -41,9 +41,12 @@ public class ElasticsearchSupportTest {
 
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
         for (int i = 1; i <= TEST_ARTICLES_COUNT; i++) {
-            ElasticTechArticle elasticTechArticle = createElasticTechArticle("타이틀" + i, createRandomDate(), "내용",
-                    "http://example.com/" + i, "설명", "http://example.com/", "작성자", company.getId(),
-                    company.getName().getCompanyName(), (long) i, (long) i, (long) i, (long) i * 10);
+            ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId_" + i, "타이틀" + i,
+                    i > 1 ? createRandomDate() : LocalDate.of(2024, 3, 11), "내용",
+                    "http://example.com/" + i, "설명", "http://example.com/", "작성자",
+                    savedCompany.getName().getCompanyName(), savedCompany.getId(), (long) i, (long) i,
+                    (long) i,
+                    (long) i * 10);
             elasticTechArticles.add(elasticTechArticle);
         }
         Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
@@ -78,14 +81,16 @@ public class ElasticsearchSupportTest {
         return startDate.plusDays(randomDays);
     }
 
-    private static ElasticTechArticle createElasticTechArticle(String title, LocalDate regDate, String contents,
+    private static ElasticTechArticle createElasticTechArticle(String id, String title, LocalDate regDate,
+                                                               String contents,
                                                                String techArticleUrl,
                                                                String description, String thumbnailUrl, String author,
-                                                               Long companyId, String company,
+                                                               String company, Long companyId,
                                                                Long viewTotalCount, Long recommendTotalCount,
                                                                Long commentTotalCount,
                                                                Long popularScore) {
         return ElasticTechArticle.builder()
+                .id(id)
                 .title(title)
                 .regDate(regDate)
                 .contents(contents)
@@ -93,8 +98,8 @@ public class ElasticsearchSupportTest {
                 .description(description)
                 .thumbnailUrl(thumbnailUrl)
                 .author(author)
-                .companyId(companyId)
                 .company(company)
+                .companyId(companyId)
                 .viewTotalCount(viewTotalCount)
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
@@ -190,7 +190,7 @@ class JwtMemberServiceTest {
         jwtMemberService.updateMemberRefreshTokenToDisabled(userPrincipal);
 
         // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                 SocialType.valueOf(socialType)).get();
         assertThat(findMember.getRefreshToken()).isEqualTo(Token.DISABLED);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -96,7 +96,8 @@ class OAuth2SuccessHandlerTest {
         oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
         // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(email), socialType).get();
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
+                socialType).get();
         Cookie accessCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_ACCESS_TOKEN);
         Cookie refreshCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN);
         Cookie loginStatusCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS);

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -328,7 +328,8 @@ class MyPageControllerTest extends SupportControllerTest {
         em.clear();
 
         // 회원 정보가 비활성화됨에 따라 조회 불가
-        Optional<Member> findMember = memberRepository.findById(member.getId());
+        Optional<Member> findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(
+                member.getEmail(), member.getSocialType());
         assertThat(findMember.isEmpty()).isEqualTo(true);
     }
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TokenControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TokenControllerTest.java
@@ -102,7 +102,7 @@ class TokenControllerTest extends SupportControllerTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(userEmail),
                 SocialType.valueOf(socialType)).get();
         mockMvc.perform(get("/devdevdev/api/v1/token/test/user")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -126,7 +126,7 @@ class TokenControllerTest extends SupportControllerTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(adminEmail),
                 SocialType.valueOf(socialType)).get();
         mockMvc.perform(get("/devdevdev/api/v1/token/test/admin")
                         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TokenControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TokenControllerDocsTest.java
@@ -137,7 +137,7 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(userEmail),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(userEmail),
                 SocialType.valueOf(socialType)).get();
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/token/test/user")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -192,7 +192,7 @@ public class TokenControllerDocsTest extends SupportControllerDocsTest {
         memberRepository.save(member);
 
         // when // then
-        Member findMember = memberRepository.findMemberByEmailAndSocialType(new Email(adminEmail),
+        Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(adminEmail),
                 SocialType.valueOf(socialType)).get();
         ResultActions actions = mockMvc.perform(get("/devdevdev/api/v1/token/test/admin")
                         .contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
# 탈퇴회원 조회 관련 수정
- Member 엔티티의 @SQLRestriction를 제거했습니다.
```java
@SQLDelete(sql = "UPDATE member SET is_deleted = true, deletedAt = NOW() WHERE id = ?")
//@SQLRestriction("is_deleted = false")
```
- MemberProvider에서 Authentication으로 회원을 조회할 때 탈퇴회원을 확인하는 구문을 추가했습니다.
```java
return memberRepository.findMemberByEmailAndSocialType(new Email(email), socialType)
                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
=>
return memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email), socialType)
                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
```

# 내작픽 수정
- 내가 작성한 픽픽픽에서 `isPicked`가 누락되는 부분을 수정했습니다. (cc. @ssosee)