### PR TITLE
[DP-228] 회원탈퇴시 서베이 완료 여부 확인

### DIFF
--- a/src/docs/asciidoc/api/mypage/exit-member.adoc
+++ b/src/docs/asciidoc/api/mypage/exit-member.adoc
@@ -32,4 +32,5 @@ include::{snippets}/mypage-member-delete/response-cookies.adoc[]
 
 ==== HTTP Response
 
+include::{snippets}/incomplete-survey-exception/response-body.adoc[]
 include::{snippets}/not-found-member-exception/response-body.adoc[]

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/MemberExceptionMessage.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/MemberExceptionMessage.java
@@ -1,0 +1,6 @@
+package com.dreamypatisiel.devdevdev.domain.exception;
+
+public class MemberExceptionMessage {
+    public static final String INVALID_MEMBER_NOT_FOUND_MESSAGE = "회원을 찾을 수 없습니다.";
+    public static final String MEMBER_INCOMPLETE_SURVEY_MESSAGE = "탈퇴 설문조사를 완료하지 않은 회원입니다.";
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/SurveyAnswerRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/SurveyAnswerRepository.java
@@ -2,9 +2,10 @@ package com.dreamypatisiel.devdevdev.domain.repository.survey;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyAnswer;
+import com.dreamypatisiel.devdevdev.domain.repository.survey.custom.SurveyAnswerRepositoryCustom;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long> {
+public interface SurveyAnswerRepository extends JpaRepository<SurveyAnswer, Long>, SurveyAnswerRepositoryCustom {
     List<SurveyAnswer> findAllByMember(Member member);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import java.util.List;
 
 public interface SurveyAnswerRepositoryCustom {
-    boolean hasAnsweredAllQuestions(Member member, List<Long> ids);
+    boolean existsByIdIn(Member member, List<Long> ids);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import java.util.List;
 
 public interface SurveyAnswerRepositoryCustom {
-    boolean existsByIdIn(Member member, List<Long> ids);
+    boolean existsByMemberAndIdIn(Member member, List<Long> ids);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dreamypatisiel.devdevdev.domain.repository.survey.custom;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import java.util.List;
+
+public interface SurveyAnswerRepositoryCustom {
+    boolean hasAnsweredAllQuestions(Member member, List<Long> ids);
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.dreamypatisiel.devdevdev.domain.repository.survey.custom;
+
+import static com.dreamypatisiel.devdevdev.domain.entity.QSurveyAnswer.surveyAnswer;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Member;
+import com.querydsl.jpa.JPQLQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SurveyAnswerRepositoryImpl implements SurveyAnswerRepositoryCustom {
+
+    private final JPQLQueryFactory query;
+
+    @Override
+    public boolean hasAnsweredAllQuestions(Member member, List<Long> ids) {
+        // 주어진 질문 ID 리스트에 대해 해당 멤버의 답변 여부를 체크
+        long answeredQuestionCount = query
+                .select(surveyAnswer.surveyQuestion.id)
+                .from(surveyAnswer)
+                .where(surveyAnswer.member.eq(member)
+                        .and(surveyAnswer.surveyQuestion.id.in(ids)))
+                .groupBy(surveyAnswer.surveyQuestion.id)
+                .fetchCount();
+
+        // 답변이 있는 질문의 수와 주어진 질문 ID 리스트의 크기가 동일하면 true 반환
+        return answeredQuestionCount == ids.size();
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
@@ -13,7 +13,7 @@ public class SurveyAnswerRepositoryImpl implements SurveyAnswerRepositoryCustom 
     private final JPQLQueryFactory query;
 
     @Override
-    public boolean existsByIdIn(Member member, List<Long> ids) {
+    public boolean existsByMemberAndIdIn(Member member, List<Long> ids) {
         // 주어진 질문 ID 리스트에 대해 해당 멤버의 답변 여부를 체크
         long answeredQuestionCount = query
                 .select(surveyAnswer.surveyQuestion.id)

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/survey/custom/SurveyAnswerRepositoryImpl.java
@@ -13,7 +13,7 @@ public class SurveyAnswerRepositoryImpl implements SurveyAnswerRepositoryCustom 
     private final JPQLQueryFactory query;
 
     @Override
-    public boolean hasAnsweredAllQuestions(Member member, List<Long> ids) {
+    public boolean existsByIdIn(Member member, List<Long> ids) {
         // 주어진 질문 ID 리스트에 대해 해당 멤버의 답변 여부를 체크
         long answeredQuestionCount = query
                 .select(surveyAnswer.surveyQuestion.id)

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService {
                 .toList();
 
         // 모든 surveyQuestions에 대해 해당 Member의 surveyAnswer이 있는지 확인
-        boolean hasAnsweredAllQuestions = surveyAnswerRepository.hasAnsweredAllQuestions(member, surveyQuestionIds);
+        boolean hasAnsweredAllQuestions = surveyAnswerRepository.existsByIdIn(member, surveyQuestionIds);
 
         // 회원 삭제
         if (!hasAnsweredAllQuestions) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -75,7 +75,7 @@ public class MemberService {
                 .toList();
 
         // 모든 surveyQuestions에 대해 해당 Member의 surveyAnswer이 있는지 확인
-        boolean hasAnsweredAllQuestions = surveyAnswerRepository.existsByIdIn(member, surveyQuestionIds);
+        boolean hasAnsweredAllQuestions = surveyAnswerRepository.existsByMemberAndIdIn(member, surveyQuestionIds);
 
         // 회원 삭제
         if (!hasAnsweredAllQuestions) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/exception/MemberException.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/exception/MemberException.java
@@ -2,8 +2,6 @@ package com.dreamypatisiel.devdevdev.exception;
 
 public class MemberException extends IllegalArgumentException {
 
-    public static final String INVALID_MEMBER_NOT_FOUND_MESSAGE = "회원을 찾을 수 없습니다.";
-
     public MemberException(String s) {
         super(s);
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/exception/SurveyException.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/exception/SurveyException.java
@@ -1,0 +1,7 @@
+package com.dreamypatisiel.devdevdev.exception;
+
+public class SurveyException extends IllegalArgumentException {
+    public SurveyException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/common/MemberProvider.java
@@ -1,5 +1,7 @@
 package com.dreamypatisiel.devdevdev.global.common;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
+
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Email;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
@@ -33,6 +35,6 @@ public class MemberProvider {
         SocialType socialType = userPrincipal.getSocialType();
 
         return memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email), socialType)
-                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER_NOT_FOUND_MESSAGE));
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberService.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.global.security.jwt.service;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.exception.TokenInvalidException.REFRESH_TOKEN_INVALID_EXCEPTION_MESSAGE;
 
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
@@ -40,7 +41,7 @@ public class JwtMemberService {
         // 회원 조회
         Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                         SocialType.valueOf(socialType))
-                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER_NOT_FOUND_MESSAGE));
 
         // 회원이 가지고 있는 리프레시 토큰과 일치 하는지?
         if (!findMember.isRefreshTokenEquals(refreshToken)) {
@@ -69,7 +70,7 @@ public class JwtMemberService {
         // 회원 조회
         Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                         SocialType.valueOf(socialType))
-                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER_NOT_FOUND_MESSAGE));
         // 리프레시 토큰 갱신
         findMember.updateRefreshToken(refreshToken);
     }
@@ -81,7 +82,7 @@ public class JwtMemberService {
 
         Member findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(new Email(email),
                         socialType)
-                .orElseThrow(() -> new MemberException(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER_NOT_FOUND_MESSAGE));
 
         findMember.updateRefreshToken(Token.DISABLED);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
@@ -2,6 +2,7 @@ package com.dreamypatisiel.devdevdev.domain.service.pick;
 
 import static com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType.firstPickOption;
 import static com.dreamypatisiel.devdevdev.domain.entity.enums.PickOptionType.secondPickOption;
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_CAN_NOT_VOTE_SAME_PICK_OPTION_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_MODIFY_MEMBER_PICK_ONLY_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_NOT_FOUND_CAN_MODIFY_PICK_MESSAGE;
@@ -448,7 +449,7 @@ class MemberPickServiceTest {
         // when // then
         assertThatThrownBy(() -> memberPickService.findPicksMain(pageable, Long.MAX_VALUE, null, null, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @ParameterizedTest
@@ -654,7 +655,7 @@ class MemberPickServiceTest {
         // when // then
         assertThatThrownBy(() -> memberPickService.registerPick(registerPickRequest, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test
@@ -798,7 +799,7 @@ class MemberPickServiceTest {
         // when // then
         assertThatThrownBy(() -> memberPickService.modifyPick(1L, modifyPickRequest, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_TECH_ARTICLE_MESSAGE;
@@ -100,7 +101,7 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         assertThatThrownBy(
                 () -> memberTechArticleService.getTechArticles(pageable, null, null, null, null, null, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test
@@ -179,7 +180,7 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         // when // then
         assertThatThrownBy(() -> memberTechArticleService.getTechArticle(id, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/common/MemberProviderTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/common/MemberProviderTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.global.common;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -72,7 +73,7 @@ class MemberProviderTest {
         // when // then
         assertThatThrownBy(() -> memberProvider.getMemberByAuthentication(authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/jwt/service/JwtMemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.global.security.jwt.service;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -101,7 +102,7 @@ class JwtMemberServiceTest {
         assertThatThrownBy(() -> jwtMemberService.validationRefreshTokenAndUpdateMemberRefreshTokenAndGetNewToken(
                 otherRefreshToken))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test
@@ -171,7 +172,7 @@ class JwtMemberServiceTest {
         // when // then
         assertThatThrownBy(() -> jwtMemberService.updateMemberRefreshToken(otherRefreshToken))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test
@@ -205,7 +206,7 @@ class JwtMemberServiceTest {
         // when // then
         assertThatThrownBy(() -> jwtMemberService.updateMemberRefreshTokenToDisabled(userPrincipal))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     private SocialMemberDto createSocialDto(String userId, String name, String nickname, String password, String email,

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -1,5 +1,6 @@
 package com.dreamypatisiel.devdevdev.global.security.oauth2.handler;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -74,7 +75,7 @@ class OAuth2SuccessHandlerTest {
         // when // then
         assertThatThrownBy(() -> oAuth2SuccessHandler.onAuthenticationSuccess(request, response, authentication))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE);
+                .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -1,6 +1,6 @@
 package com.dreamypatisiel.devdevdev.web.controller;
 
-import static com.dreamypatisiel.devdevdev.exception.MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.web.controller;
 
 import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.MEMBER_INCOMPLETE_SURVEY_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;
@@ -20,6 +21,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.Pick;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOption;
 import com.dreamypatisiel.devdevdev.domain.entity.PickVote;
+import com.dreamypatisiel.devdevdev.domain.entity.SurveyAnswer;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyQuestion;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyQuestionOption;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyVersion;
@@ -40,6 +42,7 @@ import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickVoteRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyAnswerRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyQuestionOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyQuestionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyVersionQuestionMapperRepository;
@@ -51,6 +54,7 @@ import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticle
 import com.dreamypatisiel.devdevdev.global.common.TimeProvider;
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.controller.request.RecordMemberExitSurveyAnswerRequest;
 import com.dreamypatisiel.devdevdev.web.controller.request.RecordMemberExitSurveyQuestionOptionsRequest;
@@ -75,6 +79,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.test.web.servlet.ResultActions;
 
 class MyPageControllerTest extends SupportControllerTest {
@@ -99,6 +108,8 @@ class MyPageControllerTest extends SupportControllerTest {
     SurveyVersionQuestionMapperRepository surveyVersionQuestionMapperRepository;
     @Autowired
     SurveyQuestionRepository surveyQuestionRepository;
+    @Autowired
+    SurveyAnswerRepository surveyAnswerRepository;
     @Autowired
     SurveyQuestionOptionRepository surveyQuestionOptionRepository;
     @Autowired
@@ -288,7 +299,8 @@ class MyPageControllerTest extends SupportControllerTest {
     }
 
     @Test
-    @DisplayName("회원탈퇴를 하면 회원 정보가 비활성화되고"
+    @DisplayName("탈퇴 서베이를 완료한 회원이 회원탈퇴를 하면"
+            + " 회원 정보가 비활성화되고"
             + " 리프레시 토큰 쿠키를 초기화 하고"
             + " 로그인 활성화 유무 쿠키를 비활성화 한다.")
     void deleteMember() throws Exception {
@@ -296,10 +308,66 @@ class MyPageControllerTest extends SupportControllerTest {
         SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
                 "꿈빛파티시엘", "1234", email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
-        member.updateRefreshToken(refreshToken);
-        memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
 
-        Cookie cookie = new Cookie(DEVDEVDEV_REFRESH_TOKEN, refreshToken);
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 서베이 버전 생성
+        SurveyVersion surveyVersion1 = SurveyVersion.builder()
+                .versionName("회원탈퇴-A")
+                .isActive(true)
+                .build();
+        SurveyVersion surveyVersion2 = SurveyVersion.builder()
+                .versionName("회원탈퇴-B")
+                .isActive(false)
+                .build();
+        surveyVersionRepository.saveAll(List.of(surveyVersion1, surveyVersion2));
+
+        // 서베이 질문 생성
+        SurveyQuestion question = SurveyQuestion.builder()
+                .title("#nickName님 회원 탈퇴하는 이유를 알려주세요.")
+                .content("회원 탈퇴하는 이유를 상세하게 알려주세요.")
+                .sortOrder(0)
+                .build();
+        surveyQuestionRepository.save(question);
+
+        // 서베이 매퍼 생성
+        SurveyVersionQuestionMapper mapper = SurveyVersionQuestionMapper.builder()
+                .surveyVersion(surveyVersion1)
+                .surveyQuestion(question)
+                .build();
+        surveyVersionQuestionMapperRepository.save(mapper);
+
+        // 서베이 질문 옵션 생성
+        SurveyQuestionOption option1 = SurveyQuestionOption.builder()
+                .title("채용정보가 부족해요.")
+                .sortOrder(0)
+                .build();
+        option1.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option2 = SurveyQuestionOption.builder()
+                .title("정보가 부족해요.")
+                .sortOrder(1)
+                .build();
+        option2.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option3 = SurveyQuestionOption.builder()
+                .title("기타.")
+                .sortOrder(2)
+                .build();
+        option3.changeSurveyQuestion(question);
+        surveyQuestionOptionRepository.saveAll(List.of(option1, option2, option3));
+
+        SurveyAnswer surveyAnswer = SurveyAnswer.builder()
+                .surveyQuestion(question)
+                .surveyQuestionOption(option1)
+                .member(savedMember)
+                .build();
+        surveyAnswerRepository.save(surveyAnswer);
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -331,6 +399,80 @@ class MyPageControllerTest extends SupportControllerTest {
         Optional<Member> findMember = memberRepository.findMemberByEmailAndSocialTypeAndIsDeletedIsFalse(
                 member.getEmail(), member.getSocialType());
         assertThat(findMember.isEmpty()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("탈퇴 서베이를 완료하지 않은 회원이 회원탈퇴를 할 경우 예외가 발생한다.")
+    void deleteMemberIncompleteSurvey() throws Exception {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        Member savedMember = memberRepository.save(member);
+
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 서베이 버전 생성
+        SurveyVersion surveyVersion1 = SurveyVersion.builder()
+                .versionName("회원탈퇴-A")
+                .isActive(true)
+                .build();
+        SurveyVersion surveyVersion2 = SurveyVersion.builder()
+                .versionName("회원탈퇴-B")
+                .isActive(false)
+                .build();
+        surveyVersionRepository.saveAll(List.of(surveyVersion1, surveyVersion2));
+
+        // 서베이 질문 생성
+        SurveyQuestion question = SurveyQuestion.builder()
+                .title("#nickName님 회원 탈퇴하는 이유를 알려주세요.")
+                .content("회원 탈퇴하는 이유를 상세하게 알려주세요.")
+                .sortOrder(0)
+                .build();
+        surveyQuestionRepository.save(question);
+
+        // 서베이 매퍼 생성
+        SurveyVersionQuestionMapper mapper = SurveyVersionQuestionMapper.builder()
+                .surveyVersion(surveyVersion1)
+                .surveyQuestion(question)
+                .build();
+        surveyVersionQuestionMapperRepository.save(mapper);
+
+        // 서베이 질문 옵션 생성
+        SurveyQuestionOption option1 = SurveyQuestionOption.builder()
+                .title("채용정보가 부족해요.")
+                .sortOrder(0)
+                .build();
+        option1.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option2 = SurveyQuestionOption.builder()
+                .title("정보가 부족해요.")
+                .sortOrder(1)
+                .build();
+        option2.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option3 = SurveyQuestionOption.builder()
+                .title("기타.")
+                .sortOrder(2)
+                .build();
+        option3.changeSurveyQuestion(question);
+        surveyQuestionOptionRepository.saveAll(List.of(option1, option2, option3));
+
+        // when // then
+        ResultActions actions = mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding(StandardCharsets.UTF_8)
+                                .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultType").value(ResultType.FAIL.name()))
+                .andExpect(jsonPath("$.message").value(MEMBER_INCOMPLETE_SURVEY_MESSAGE))
+                .andExpect(jsonPath("$.errorCode").value(HttpStatus.BAD_REQUEST.value()));
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
@@ -1,11 +1,11 @@
 package com.dreamypatisiel.devdevdev.web.controller;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_CURSOR_SCORE_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_ID_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_ELASTIC_TECH_ARTICLE_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.NOT_FOUND_TECH_ARTICLE_MESSAGE;
-import static com.dreamypatisiel.devdevdev.exception.MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -1,6 +1,6 @@
 package com.dreamypatisiel.devdevdev.web.docs;
 
-import static com.dreamypatisiel.devdevdev.exception.MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.web.docs;
 
 import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.MEMBER_INCOMPLETE_SURVEY_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_LOGIN_STATUS;
 import static com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant.DEVDEVDEV_REFRESH_TOKEN;
@@ -13,6 +14,7 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.responseC
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -38,6 +40,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.Pick;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOption;
 import com.dreamypatisiel.devdevdev.domain.entity.PickVote;
+import com.dreamypatisiel.devdevdev.domain.entity.SurveyAnswer;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyQuestion;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyQuestionOption;
 import com.dreamypatisiel.devdevdev.domain.entity.SurveyVersion;
@@ -58,6 +61,7 @@ import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickVoteRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyAnswerRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyQuestionOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyQuestionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.survey.SurveyVersionQuestionMapperRepository;
@@ -68,11 +72,11 @@ import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
 import com.dreamypatisiel.devdevdev.elastic.domain.repository.ElasticTechArticleRepository;
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.web.controller.request.RecordMemberExitSurveyAnswerRequest;
 import com.dreamypatisiel.devdevdev.web.controller.request.RecordMemberExitSurveyQuestionOptionsRequest;
 import com.dreamypatisiel.devdevdev.web.response.ResultType;
 import jakarta.persistence.EntityManager;
-import jakarta.servlet.http.Cookie;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -90,6 +94,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.test.web.servlet.ResultActions;
 
 public class MyPageControllerDocsTest extends SupportControllerDocsTest {
@@ -118,6 +126,8 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
     SurveyVersionQuestionMapperRepository surveyVersionQuestionMapperRepository;
     @Autowired
     SurveyQuestionRepository surveyQuestionRepository;
+    @Autowired
+    SurveyAnswerRepository surveyAnswerRepository;
     @Autowired
     SurveyQuestionOptionRepository surveyQuestionOptionRepository;
     @Autowired
@@ -273,7 +283,6 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
     void getBookmarkedTechArticlesNotFoundMemberException() throws Exception {
         // given
         Long id = FIRST_TECH_ARTICLE_ID;
-        // given
         SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
                 "꿈빛파티시엘", "1234", email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
@@ -302,20 +311,79 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
     }
 
     @Test
-    @DisplayName("회원이 회원탈퇴를 한다.")
+    @DisplayName("탈퇴 서베이를 완료한 회원이 회원탈퇴를 하면"
+            + " 회원 정보가 비활성화되고"
+            + " 리프레시 토큰 쿠키를 초기화 하고"
+            + " 로그인 활성화 유무 쿠키를 비활성화 한다.")
     void deleteMember() throws Exception {
         // given
         SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
                 "꿈빛파티시엘", "1234", email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
-        member.updateRefreshToken(refreshToken);
-        memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
 
-        Cookie cookie = new Cookie(DEVDEVDEV_REFRESH_TOKEN, refreshToken);
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 서베이 버전 생성
+        SurveyVersion surveyVersion1 = SurveyVersion.builder()
+                .versionName("회원탈퇴-A")
+                .isActive(true)
+                .build();
+        SurveyVersion surveyVersion2 = SurveyVersion.builder()
+                .versionName("회원탈퇴-B")
+                .isActive(false)
+                .build();
+        surveyVersionRepository.saveAll(List.of(surveyVersion1, surveyVersion2));
+
+        // 서베이 질문 생성
+        SurveyQuestion question = SurveyQuestion.builder()
+                .title("#nickName님 회원 탈퇴하는 이유를 알려주세요.")
+                .content("회원 탈퇴하는 이유를 상세하게 알려주세요.")
+                .sortOrder(0)
+                .build();
+        surveyQuestionRepository.save(question);
+
+        // 서베이 매퍼 생성
+        SurveyVersionQuestionMapper mapper = SurveyVersionQuestionMapper.builder()
+                .surveyVersion(surveyVersion1)
+                .surveyQuestion(question)
+                .build();
+        surveyVersionQuestionMapperRepository.save(mapper);
+
+        // 서베이 질문 옵션 생성
+        SurveyQuestionOption option1 = SurveyQuestionOption.builder()
+                .title("채용정보가 부족해요.")
+                .sortOrder(0)
+                .build();
+        option1.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option2 = SurveyQuestionOption.builder()
+                .title("정보가 부족해요.")
+                .sortOrder(1)
+                .build();
+        option2.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option3 = SurveyQuestionOption.builder()
+                .title("기타.")
+                .sortOrder(2)
+                .build();
+        option3.changeSurveyQuestion(question);
+        surveyQuestionOptionRepository.saveAll(List.of(option1, option2, option3));
+
+        SurveyAnswer surveyAnswer = SurveyAnswer.builder()
+                .surveyQuestion(question)
+                .surveyQuestionOption(option1)
+                .member(savedMember)
+                .build();
+        surveyAnswerRepository.save(surveyAnswer);
 
         // when // then
         ResultActions actions = mockMvc.perform(
-                        RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/profile")
+                        delete(DEFAULT_PATH_V1 + "/mypage/profile")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .characterEncoding(StandardCharsets.UTF_8)
                                 .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -336,6 +404,90 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
                 ),
                 responseFields(
                         fieldWithPath("resultType").type(JsonFieldType.STRING).description("응답 결과")
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("탈퇴 서베이를 완료하지 않은 회원이 회원탈퇴를 할 경우 예외가 발생한다.")
+    void deleteMemberIncompleteSurvey() throws Exception {
+        // given
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        Member savedMember = memberRepository.save(member);
+
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 서베이 버전 생성
+        SurveyVersion surveyVersion1 = SurveyVersion.builder()
+                .versionName("회원탈퇴-A")
+                .isActive(true)
+                .build();
+        SurveyVersion surveyVersion2 = SurveyVersion.builder()
+                .versionName("회원탈퇴-B")
+                .isActive(false)
+                .build();
+        surveyVersionRepository.saveAll(List.of(surveyVersion1, surveyVersion2));
+
+        // 서베이 질문 생성
+        SurveyQuestion question = SurveyQuestion.builder()
+                .title("#nickName님 회원 탈퇴하는 이유를 알려주세요.")
+                .content("회원 탈퇴하는 이유를 상세하게 알려주세요.")
+                .sortOrder(0)
+                .build();
+        surveyQuestionRepository.save(question);
+
+        // 서베이 매퍼 생성
+        SurveyVersionQuestionMapper mapper = SurveyVersionQuestionMapper.builder()
+                .surveyVersion(surveyVersion1)
+                .surveyQuestion(question)
+                .build();
+        surveyVersionQuestionMapperRepository.save(mapper);
+
+        // 서베이 질문 옵션 생성
+        SurveyQuestionOption option1 = SurveyQuestionOption.builder()
+                .title("채용정보가 부족해요.")
+                .sortOrder(0)
+                .build();
+        option1.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option2 = SurveyQuestionOption.builder()
+                .title("정보가 부족해요.")
+                .sortOrder(1)
+                .build();
+        option2.changeSurveyQuestion(question);
+
+        SurveyQuestionOption option3 = SurveyQuestionOption.builder()
+                .title("기타.")
+                .sortOrder(2)
+                .build();
+        option3.changeSurveyQuestion(question);
+        surveyQuestionOptionRepository.saveAll(List.of(option1, option2, option3));
+
+        // when // then
+        ResultActions actions = mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/devdevdev/api/v1/mypage/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding(StandardCharsets.UTF_8)
+                                .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultType").value(ResultType.FAIL.name()))
+                .andExpect(jsonPath("$.message").value(MEMBER_INCOMPLETE_SURVEY_MESSAGE))
+                .andExpect(jsonPath("$.errorCode").value(HttpStatus.BAD_REQUEST.value()));
+
+        // Docs
+        actions.andDo(document("incomplete-survey-exception",
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                        fieldWithPath("resultType").type(JsonFieldType.STRING).description("응답 결과"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                        fieldWithPath("errorCode").type(JsonFieldType.NUMBER).description("에러 코드")
                 )
         ));
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -1,7 +1,7 @@
 package com.dreamypatisiel.devdevdev.web.docs;
 
+import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.KEYWORD_WITH_SPECIAL_SYMBOLS_EXCEPTION_MESSAGE;
-import static com.dreamypatisiel.devdevdev.exception.MemberException.INVALID_MEMBER_NOT_FOUND_MESSAGE;
 import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTHORIZATION_HEADER;
 import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.authenticationType;
 import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.techArticleSortType;


### PR DESCRIPTION
## 회원탈퇴 API 변경사항
- 탈퇴를 요청하는 회원이 모든 회원탈퇴 서베이 질문에 대해 답변을 완료했는지 확인합니다.
   - 만약 서베이를 완료하지 않은 회원이 탈퇴를 요청할 경우 예외가 발생합니다.
```java
public boolean hasAnsweredAllQuestions(Member member, List<Long> ids) {
    // 주어진 질문 ID 리스트에 대해 해당 멤버의 답변 여부를 체크
    long answeredQuestionCount = query
            .select(surveyAnswer.surveyQuestion.id)
            .from(surveyAnswer)
            .where(surveyAnswer.member.eq(member)
                    .and(surveyAnswer.surveyQuestion.id.in(ids)))
            .groupBy(surveyAnswer.surveyQuestion.id)
            .fetchCount();

    // 답변이 있는 질문의 수와 주어진 질문 ID 리스트의 크기가 동일하면 true 반환
    return answeredQuestionCount == ids.size();
}
```