### PR TITLE
[DP-255] 썸네일 이미지 없을 시 회사 로고 이미지 전달

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
@@ -147,14 +147,14 @@ public class LocalInitData {
 
     private List<Company> createCompanies() {
         List<Company> companies = new ArrayList<>();
-        companies.add(Company.of(new CompanyName("Toss"), new Url("https://toss.tech"),
-                new Url("https://toss.im/career/jobs")));
-        companies.add(Company.of(new CompanyName("우아한 형제들"), new Url("https://techblog.woowahan.com"),
-                new Url("https://career.woowahan.com")));
-        companies.add(Company.of(new CompanyName("AWS"), new Url("https://aws.amazon.com/ko/blogs/tech"),
-                new Url("https://aws.amazon.com/ko/careers")));
-        companies.add(Company.of(new CompanyName("채널톡"), new Url("https://channel.io/ko/blog"),
-                new Url("https://channel.io/ko/jobs")));
+        companies.add(createCompany("Toss", "https://toss.tech",
+                "https://toss.im/career/jobs"));
+        companies.add(createCompany("우아한 형제들", "https://techblog.woowahan.com",
+                "https://career.woowahan.com"));
+        companies.add(createCompany("AWS", "https://aws.amazon.com/ko/blogs/tech",
+                "https://aws.amazon.com/ko/careers"));
+        companies.add(createCompany("채널톡", "https://channel.io/ko/blog",
+                "https://channel.io/ko/jobs"));
         return companies;
     }
 
@@ -164,6 +164,14 @@ public class LocalInitData {
                         Company::getId,
                         Function.identity()
                 ));
+    }
+
+    private static Company createCompany(String companyName, String thumbnailUrl, String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
+                .build();
     }
 
     private List<Bookmark> createBookmarks(Member member, List<TechArticle> techArticles) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Company.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Company.java
@@ -2,14 +2,20 @@ package com.dreamypatisiel.devdevdev.domain.entity;
 
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.CompanyName;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
-import jakarta.persistence.*;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -29,6 +35,9 @@ public class Company extends BasicTime {
             column = @Column(name = "thumbnailUrl")
     )
     private Url thumbnailUrl;
+
+    private String thumbnailImageUrl;
+
     @Embedded
     @AttributeOverride(name = "url",
             column = @Column(name = "careerUrl")
@@ -39,23 +48,17 @@ public class Company extends BasicTime {
     private List<TechArticle> techArticles = new ArrayList<>();
 
     @Builder
-    private Company(CompanyName name, Url thumbnailUrl, Url careerUrl, List<TechArticle> techArticles) {
+    private Company(CompanyName name, Url thumbnailUrl, String thumbnailImageUrl, Url careerUrl,
+                    List<TechArticle> techArticles) {
         this.name = name;
         this.thumbnailUrl = thumbnailUrl;
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.careerUrl = careerUrl;
         this.techArticles = techArticles;
     }
 
-    public static Company of(CompanyName name, Url thumbnailUrl, Url careerUrl) {
-        return Company.builder()
-                .name(name)
-                .thumbnailUrl(thumbnailUrl)
-                .careerUrl(careerUrl)
-                .build();
-    }
-
     public void changeTechArticles(List<TechArticle> techArticles) {
-        for(TechArticle techArticle : techArticles) {
+        for (TechArticle techArticle : techArticles) {
             techArticle.changeCompany(this);
             this.getTechArticles().add(techArticle);
         }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/CompanyResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/CompanyResponse.java
@@ -10,12 +10,14 @@ public class CompanyResponse {
     public final Long id;
     public final String name;
     public final String careerUrl;
+    public final String thumbnailImageUrl;
 
     @Builder
-    private CompanyResponse(Long id, String name, String careerUrl) {
+    private CompanyResponse(Long id, String name, String careerUrl, String thumbnailImageUrl) {
         this.id = id;
         this.name = name;
         this.careerUrl = careerUrl;
+        this.thumbnailImageUrl = thumbnailImageUrl;
     }
 
     public static CompanyResponse of(Long id, String name, String careerUrl) {
@@ -31,6 +33,7 @@ public class CompanyResponse {
                 .id(company.getId())
                 .name(company.getName().getCompanyName())
                 .careerUrl(company.getCareerUrl().getUrl())
+                .thumbnailImageUrl(company.getThumbnailImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleMainResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleMainResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.util.ObjectUtils;
 
 @Data
 public class TechArticleMainResponse {
@@ -64,7 +65,7 @@ public class TechArticleMainResponse {
                 .commentTotalCount(techArticle.getCommentTotalCount().getCount())
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
-                .thumbnailUrl(elasticTechArticle.getThumbnailUrl())
+                .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .company(companyResponse)
@@ -86,7 +87,7 @@ public class TechArticleMainResponse {
                 .commentTotalCount(techArticle.getCommentTotalCount().getCount())
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
-                .thumbnailUrl(elasticTechArticle.getThumbnailUrl())
+                .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .company(companyResponse)
@@ -108,7 +109,7 @@ public class TechArticleMainResponse {
                 .commentTotalCount(techArticle.getCommentTotalCount().getCount())
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
-                .thumbnailUrl(elasticTechArticle.getThumbnailUrl())
+                .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .contents(truncateString(elasticTechArticle.getContents(), CONTENTS_MAX_LENGTH))
@@ -132,7 +133,7 @@ public class TechArticleMainResponse {
                 .commentTotalCount(techArticle.getCommentTotalCount().getCount())
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
-                .thumbnailUrl(elasticTechArticle.getThumbnailUrl())
+                .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .contents(truncateString(elasticTechArticle.getContents(), CONTENTS_MAX_LENGTH))
@@ -142,6 +143,15 @@ public class TechArticleMainResponse {
                 .score(getValidScore(score))
                 .isBookmarked(isBookmarkedByMember(techArticle, member))
                 .build();
+    }
+
+    private static String getThumbnailUrl(ElasticTechArticle elasticTechArticle, CompanyResponse companyResponse) {
+        // 썸네일 이미지가 없다면 회사 로고로 내려준다.
+        if (ObjectUtils.isEmpty(elasticTechArticle.getThumbnailUrl())) {
+            return companyResponse.getThumbnailImageUrl();
+        }
+
+        return elasticTechArticle.getThumbnailUrl();
     }
 
     private static Float getValidScore(Float score) {

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleMainResponseTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/response/TechArticleMainResponseTest.java
@@ -1,0 +1,71 @@
+package com.dreamypatisiel.devdevdev.domain.service.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Company;
+import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.CompanyName;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
+import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TechArticleMainResponseTest {
+
+    @Test
+    @DisplayName("기술블로그 썸네일 이미지가 없으면 회사 로고 이미지가 썸네일로 들어간다.")
+    void companyLogoAsDefaultThumbnailWhenNoThumbnail() {
+        // given
+        ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId", "타이틀", "내용",
+                "http://example.com/", "설명", null, "작성자",
+                "꿈빛 파티시엘", 1L, 1L, 1L, 1L, 1L);
+
+        Company company = createCompany("꿈빛 파티시엘", "https://companylogo.png", "https://example.com",
+                "https://example.com");
+
+        TechArticle techArticle = TechArticle.of(elasticTechArticle, company);
+        CompanyResponse companyResponse = CompanyResponse.from(company);
+
+        // when
+        TechArticleMainResponse techArticleMainResponse = TechArticleMainResponse.of(techArticle, elasticTechArticle,
+                companyResponse);
+
+        // then
+        assertThat(techArticleMainResponse.getThumbnailUrl()).isEqualTo(company.getThumbnailImageUrl());
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
+                .build();
+    }
+
+    private static ElasticTechArticle createElasticTechArticle(String id, String title,
+                                                               String contents,
+                                                               String techArticleUrl,
+                                                               String description, String thumbnailUrl, String author,
+                                                               String company, Long companyId,
+                                                               Long viewTotalCount, Long recommendTotalCount,
+                                                               Long commentTotalCount,
+                                                               Long popularScore) {
+        return ElasticTechArticle.builder()
+                .id(id)
+                .title(title)
+                .contents(contents)
+                .techArticleUrl(techArticleUrl)
+                .description(description)
+                .thumbnailUrl(thumbnailUrl)
+                .author(author)
+                .company(company)
+                .companyId(companyId)
+                .viewTotalCount(viewTotalCount)
+                .recommendTotalCount(recommendTotalCount)
+                .commentTotalCount(commentTotalCount)
+                .popularScore(popularScore)
+                .build();
+    }
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticsearchSupportTest.java
@@ -35,8 +35,8 @@ public class ElasticsearchSupportTest {
                       @Autowired CompanyRepository companyRepository,
                       @Autowired ElasticTechArticleRepository elasticTechArticleRepository) {
 
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
-                new Url("https://example.com"));
+        Company company = createCompany("꿈빛 파티시엘", "https://example.png", "https://example.com", "https://example.com");
+
         Company savedCompany = companyRepository.save(company);
 
         List<ElasticTechArticle> elasticTechArticles = new ArrayList<>();
@@ -104,6 +104,16 @@ public class ElasticsearchSupportTest {
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)
                 .popularScore(popularScore)
+                .build();
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
                 .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/MyPageControllerTest.java
@@ -133,8 +133,8 @@ class MyPageControllerTest extends SupportControllerTest {
         }
         Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
                 elasticTechArticles);
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
-                new Url("https://example.com"));
+        Company company = createCompany("꿈빛 파티시엘", "https://example.png", "https://example.com", "https://example.com");
+
         Company savedCompany = companyRepository.save(company);
 
         techArticles = new ArrayList<>();
@@ -881,6 +881,16 @@ class MyPageControllerTest extends SupportControllerTest {
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)
                 .popularScore(popularScore)
+                .build();
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
                 .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/TechArticleControllerTest.java
@@ -79,8 +79,8 @@ class TechArticleControllerTest extends SupportControllerTest {
         }
         Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
                 elasticTechArticles);
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
-                new Url("https://example.com"));
+        Company company = createCompany("꿈빛 파티시엘", "https://example.png", "https://example.com", "https://example.com");
+
         Company savedCompany = companyRepository.save(company);
 
         techArticles = new ArrayList<>();
@@ -596,6 +596,16 @@ class TechArticleControllerTest extends SupportControllerTest {
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)
                 .popularScore(popularScore)
+                .build();
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
                 .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -149,8 +149,8 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
         }
         Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
                 elasticTechArticles);
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
-                new Url("https://example.com"));
+        Company company = createCompany("꿈빛 파티시엘", "https://example.png", "https://example.com", "https://example.com");
+
         Company savedCompany = companyRepository.save(company);
 
         techArticles = new ArrayList<>();
@@ -233,6 +233,8 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
                                 .description("기술블로그 회사 이름"),
                         fieldWithPath("data.content.[].company.careerUrl").type(JsonFieldType.STRING)
                                 .description("기술블로그 회사 채용페이지"),
+                        fieldWithPath("data.content.[].company.thumbnailImageUrl").type(JsonFieldType.STRING)
+                                .description("기술블로그 회사 로고 이미지"),
                         fieldWithPath("data.content.[].regDate").type(JsonFieldType.STRING).description("기술블로그 작성일"),
                         fieldWithPath("data.content.[].author").type(JsonFieldType.STRING).description("기술블로그 작성자"),
                         fieldWithPath("data.content.[].viewTotalCount").type(JsonFieldType.NUMBER)
@@ -976,6 +978,16 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)
                 .popularScore(popularScore)
+                .build();
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
                 .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -94,8 +94,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         }
         Iterable<ElasticTechArticle> elasticTechArticleIterable = elasticTechArticleRepository.saveAll(
                 elasticTechArticles);
-        Company company = Company.of(new CompanyName("꿈빛 파티시엘"), new Url("https://example.com"),
-                new Url("https://example.com"));
+        Company company = createCompany("꿈빛 파티시엘", "https://example.png", "https://example.com", "https://example.com");
         Company savedCompany = companyRepository.save(company);
 
         techArticles = new ArrayList<>();
@@ -189,6 +188,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                                 .description("기술블로그 회사 이름"),
                         fieldWithPath("data.content.[].company.careerUrl").type(JsonFieldType.STRING)
                                 .description("기술블로그 회사 채용페이지"),
+                        fieldWithPath("data.content.[].company.thumbnailImageUrl").type(JsonFieldType.STRING)
+                                .description("기술블로그 회사 로고 이미지"),
                         fieldWithPath("data.content.[].regDate").type(JsonFieldType.STRING).description("기술블로그 작성일"),
                         fieldWithPath("data.content.[].author").type(JsonFieldType.STRING).description("기술블로그 작성자"),
                         fieldWithPath("data.content.[].viewTotalCount").type(JsonFieldType.NUMBER)
@@ -366,6 +367,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         fieldWithPath("data.company.name").type(JsonFieldType.STRING).description("기술블로그 회사 이름"),
                         fieldWithPath("data.company.careerUrl").type(JsonFieldType.STRING)
                                 .description("기술블로그 회사 채용페이지"),
+                        fieldWithPath("data.company.thumbnailImageUrl").type(JsonFieldType.STRING)
+                                .description("기술블로그 회사 로고 이미지"),
                         fieldWithPath("data.regDate").type(JsonFieldType.STRING).description("기술블로그 작성일"),
                         fieldWithPath("data.author").type(JsonFieldType.STRING).description("기술블로그 작성자"),
                         fieldWithPath("data.contents").type(JsonFieldType.STRING).description("기술블로그 내용"),
@@ -597,6 +600,16 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                 .recommendTotalCount(recommendTotalCount)
                 .commentTotalCount(commentTotalCount)
                 .popularScore(popularScore)
+                .build();
+    }
+
+    private static Company createCompany(String companyName, String thumbnailImageUrl, String thumbnailUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .careerUrl(new Url(thumbnailUrl))
+                .thumbnailUrl(new Url(careerUrl))
                 .build();
     }
 }


### PR DESCRIPTION
## 썸네일 이미지 없을 시 회사 로고 이미지 전달

### Company 엔티티에 회사로고 이미지(thumbnailImageUrl)이 추가되었습니다.
  - 이미지는 S3에 업로드되어있어요.
  - 이미지 Url 이므로 타입은 String으로 지정했습니다.
  
### 기술블로그 메인 조회 시
  - Company 응답에 회사로고 이미지가 포함됩니다.
  - 만약 기술블로그의 썸네일 이미지가 없다면 회사로고 이미지가 해당 값으로 들어갑니다.(프론트에서 추가 공수가 들지 않도록 하기 위함)

```
"content" : [ {
      "id" : 1,
      "thumbnailUrl" : "http://companyLogo.png", // 만약 기술블로그의 썸네일 이미지가 없다면 회사로고 이미지가 해당 값으로 들어갑니다.
      "techArticleUrl" : "http://example.com/9",
      ...
      "company" : {
        "id" : 2,
        "name" : "꿈빛 파티시엘",
        "careerUrl" : "https://example.com",
        "thumbnailImageUrl" : "https://companyLogo.png" // Company 응답에 회사로고 이미지가 포함됩니다.
      }
}]
```