### PR TITLE
[DP-328] 픽픽픽 투표 응답 버그 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/AnonymousMember.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/AnonymousMember.java
@@ -39,7 +39,7 @@ public class AnonymousMember extends BasicTime {
         return anonymousMember;
     }
 
-    public boolean isEqualAnonymousMember(AnonymousMember anonymousMember) {
-        return this.equals(anonymousMember);
+    public boolean isEqualAnonymousMember(Long id) {
+        return this.id.equals(id);
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -171,8 +171,8 @@ public class Member extends BasicTime {
         return nickname.getNickname();
     }
 
-    public boolean isEqualMember(Member member) {
-        return this.equals(member);
+    public boolean isEqualId(Long id) {
+        return this.id.equals(id);
     }
 
     public boolean isAdmin() {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Pick.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Pick.java
@@ -149,10 +149,6 @@ public class Pick extends BasicTime {
         }
     }
 
-    public boolean isEqualsPick(Pick pick) {
-        return this.equals(pick);
-    }
-
     public boolean isEqualsId(Long id) {
         return this.id.equals(id);
     }
@@ -166,7 +162,7 @@ public class Pick extends BasicTime {
     }
 
     public boolean isEqualMember(Member member) {
-        return this.member.isEqualMember(member);
+        return this.member.equals(member);
     }
 
     public void changeTitle(String title) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/PickResponseUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/PickResponseUtils.java
@@ -9,14 +9,14 @@ public class PickResponseUtils {
 
     public static boolean isVotedMember(Pick pick, Member member) {
         return pick.getPickVotes().stream()
-                .filter(pickVote -> pickVote.getPick().isEqualsPick(pick) && pickVote.isMemberNotNull())
-                .anyMatch(pickVote -> pickVote.getMember().isEqualMember(member));
+                .filter(pickVote -> pickVote.getPick().isEqualsId(pick.getId()) && pickVote.isMemberNotNull())
+                .anyMatch(pickVote -> pickVote.getMember().isEqualId(member.getId()));
     }
 
     public static boolean isVotedAnonymousMember(Pick pick, AnonymousMember anonymousMember) {
         return pick.getPickVotes().stream()
-                .filter(pickVote -> pickVote.getPick().isEqualsPick(pick) && pickVote.isAnonymousMemberNotNull())
-                .anyMatch(pickVote -> pickVote.getAnonymousMember().isEqualAnonymousMember(anonymousMember));
+                .filter(pickVote -> pickVote.getPick().isEqualsId(pick.getId()) && pickVote.isAnonymousMemberNotNull())
+                .anyMatch(pickVote -> pickVote.getAnonymousMember().isEqualAnonymousMember(anonymousMember.getId()));
     }
 
     public static boolean isPickedPickOptionByMember(Pick pick, PickOption pickOption,
@@ -24,7 +24,7 @@ public class PickResponseUtils {
         return pick.getPickVotes().stream()
                 .filter(pickVote -> pickVote.getPickOption().isEqualsId(pickOption.getId())
                         && pickVote.isMemberNotNull())
-                .anyMatch(pickVote -> pickVote.getMember().isEqualMember(member));
+                .anyMatch(pickVote -> pickVote.getMember().isEqualId(member.getId()));
     }
 
     public static boolean isPickedPickOptionByAnonymousMember(Pick pick, PickOption pickOption,
@@ -32,7 +32,7 @@ public class PickResponseUtils {
         return pick.getPickVotes().stream()
                 .filter(pickVote -> pickVote.getPickOption().isEqualsId(pickOption.getId())
                         && pickVote.isAnonymousMemberNotNull())
-                .anyMatch(pickVote -> pickVote.getAnonymousMember().isEqualAnonymousMember(anonymousMember));
+                .anyMatch(pickVote -> pickVote.getAnonymousMember().isEqualAnonymousMember(anonymousMember.getId()));
     }
 
     public static String sliceAndMaskEmail(String email) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/TechArticleResponseUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/response/util/TechArticleResponseUtils.java
@@ -12,7 +12,7 @@ public class TechArticleResponseUtils {
 
     public static boolean isBookmarkedByMember(TechArticle techArticle, Member member) {
         Optional<Bookmark> bookmarks = techArticle.getBookmarks().stream()
-                .filter(bookmark -> bookmark.getMember().isEqualMember(member))
+                .filter(bookmark -> bookmark.getMember().isEqualId(member.getId()))
                 .findAny();
 
         return bookmarks.map(Bookmark::isBookmarked).orElse(false);


### PR DESCRIPTION
* 픽픽픽 메인 API 에서 투표를 했는데, 투표를 안한 것으로 응답하는 현상 발견(사진참고)
* PickResponseUtils 수정
  * object.equals() 에서 object.id.equals() 로 변경

![image](https://github.com/user-attachments/assets/512ef520-da39-41e8-aa9d-b75b7301ddb0)

![image](https://github.com/user-attachments/assets/5024e113-4ce0-436b-972d-5544f500101b)

