### PR TITLE
[DP-252] 한글 초성 검색, 자/모음 분리 검색 가능하도록 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/document/ElasticKeyword.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/document/ElasticKeyword.java
@@ -1,11 +1,11 @@
 package com.dreamypatisiel.devdevdev.elastic.domain.document;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.CompletionField;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 @Getter
 @Document(indexName = "keywords" + "#{@elasticsearchIndexConfigService.getIndexName()}")
@@ -13,18 +13,18 @@ public class ElasticKeyword {
     @Id
     private String id;
 
-    @CompletionField
-    private List<String> words;
+    @Field(type = FieldType.Text)
+    private String keyword;
 
     @Builder
-    private ElasticKeyword(String id, List<String> words) {
+    private ElasticKeyword(String id, String keyword) {
         this.id = id;
-        this.words = words;
+        this.keyword = keyword;
     }
 
-    public static ElasticKeyword create(List<String> words) {
+    public static ElasticKeyword create(String keyword) {
         return ElasticKeyword.builder()
-                .words(words)
+                .keyword(keyword)
                 .build();
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticKeywordService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticKeywordService.java
@@ -1,8 +1,8 @@
 package com.dreamypatisiel.devdevdev.elastic.domain.service;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
@@ -10,10 +10,9 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.suggest.SuggestBuilder;
-import org.opensearch.search.suggest.SuggestBuilders;
-import org.opensearch.search.suggest.completion.CompletionSuggestionBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -25,8 +24,8 @@ public class ElasticKeywordService {
     @Value("#{@elasticsearchIndexConfigService.getIndexName()}")
     private String INDEX_NAME_POSTFIX;
     public static final String INDEX_NAME = "keywords";
-    public static final String SUGGEST_FIELD_NAME = "words";
-    public static final String SUGGESTION_KEY = "suggest";
+    public static final String FIELD_NAME = "keyword";
+    public static final String[] MULTI_FIELD_NAMES = {"keyword", "keyword.nfc", "keyword.chosung"};
     public static final int AUTOCOMPLETION_MAX_SIZE = 20;
 
 
@@ -34,27 +33,24 @@ public class ElasticKeywordService {
 
     public List<String> autocompleteKeyword(String prefix) throws IOException {
 
-        // suggest 쿼리 생성
-        CompletionSuggestionBuilder completionSuggestionBuilder = SuggestBuilders
-                .completionSuggestion(SUGGEST_FIELD_NAME)
-                .prefix(prefix, Fuzziness.ZERO) // Fuzziness를 0으로 설정하여 정확히 일치하는 키워드만 검색
-                .size(AUTOCOMPLETION_MAX_SIZE); // 최대 20개 조회
-
-        SuggestBuilder suggestBuilder = new SuggestBuilder()
-                .addSuggestion(SUGGESTION_KEY, completionSuggestionBuilder);
+        MultiMatchQueryBuilder multiMatchQueryBuilder = QueryBuilders.multiMatchQuery(
+                prefix, // 검색할 쿼리 스트링
+                MULTI_FIELD_NAMES); // multi-match 쿼리를 실행할 필드 목록 정의
+        multiMatchQueryBuilder.fuzziness(Fuzziness.ZERO); // Fuzziness를 0으로 설정하여 정확히 일치하는 키워드만 검색
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-                .suggest(suggestBuilder);
+                .query(multiMatchQueryBuilder)
+                .size(AUTOCOMPLETION_MAX_SIZE); // 최대 20개 조회
 
+        // 조회 쿼리 생성
         SearchRequest searchRequest = new SearchRequest(INDEX_NAME + INDEX_NAME_POSTFIX)
                 .source(searchSourceBuilder);
 
         // 응답 데이터 가공
         SearchResponse searchResponse = elasticsearchClient.search(searchRequest, RequestOptions.DEFAULT);
-        return searchResponse.getSuggest().getSuggestion(SUGGESTION_KEY).getEntries().stream()
-                .flatMap(entry -> entry.getOptions().stream())
-                .map(option -> option.getText().string())
-                .collect(Collectors.toList());
+        return Arrays.stream(searchResponse.getHits().getHits())
+                .map(hit -> hit.getSourceAsMap().get(FIELD_NAME).toString())
+                .toList();
     }
 }
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticKeywordServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/elastic/domain/service/ElasticKeywordServiceTest.java
@@ -32,11 +32,11 @@ class ElasticKeywordServiceTest {
     @DisplayName("검색어와 prefix가 일치하는 키워드를 조회한다.")
     void autocompleteKeyword() throws IOException {
         // given
-        ElasticKeyword keyword1 = ElasticKeyword.create(List.of("자바", "Java"));
-        ElasticKeyword keyword2 = ElasticKeyword.create(List.of("자바스크립트", "JavaScript"));
-        ElasticKeyword keyword3 = ElasticKeyword.create(List.of("스프링", "Spring"));
-        ElasticKeyword keyword4 = ElasticKeyword.create(List.of("스프링부트", "SpringBoot"));
-        ElasticKeyword keyword5 = ElasticKeyword.create(List.of("챗지피티", "ChatGPT"));
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링부트");
+        ElasticKeyword keyword5 = ElasticKeyword.create("챗지피티");
         List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
         elasticKeywordRepository.saveAll(elasticKeywords);
 
@@ -51,15 +51,61 @@ class ElasticKeywordServiceTest {
                 .contains("자바", "자바스크립트");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"ㅈ", "자", "잡", "ㅈㅏ", "ㅈㅏㅂ", "ㅈㅏㅂㅏ"})
+    @DisplayName("한글 검색어의 경우 자음, 모음을 분리하여 검색할 수 있다.")
+    void autocompleteKoreanKeywordBySeparatingConsonantsAndVowels(String prefix) throws IOException {
+        // given
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링부트");
+        ElasticKeyword keyword5 = ElasticKeyword.create("챗지피티");
+        List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
+        elasticKeywordRepository.saveAll(elasticKeywords);
+
+        // when
+        List<String> keywords = elasticKeywordService.autocompleteKeyword(prefix);
+
+        // then
+        assertThat(keywords)
+                .hasSize(2)
+                .contains("자바", "자바스크립트");
+    }
+
+    @Test
+    @DisplayName("한글 검색어의 경우 초성검색을 할 수 있다.")
+    void autocompleteKoreanKeywordByChosung() throws IOException {
+        // given
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링부트");
+        ElasticKeyword keyword5 = ElasticKeyword.create("챗지피티");
+        List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
+        elasticKeywordRepository.saveAll(elasticKeywords);
+
+        String prefix = "ㅅㅍㄹ";
+
+        // when
+        List<String> keywords = elasticKeywordService.autocompleteKeyword(prefix);
+
+        // then
+        assertThat(keywords)
+                .hasSize(2)
+                .contains("스프링", "스프링부트");
+    }
+
+
     @Test
     @DisplayName("영어 대소문자 상관없이 키워드를 조회한다.")
     void autocompleteKeywordRegardlessOfAlphaCase() throws IOException {
         // given
-        ElasticKeyword keyword1 = ElasticKeyword.create(List.of("자바", "Java"));
-        ElasticKeyword keyword2 = ElasticKeyword.create(List.of("자바스크립트", "JavaScript"));
-        ElasticKeyword keyword3 = ElasticKeyword.create(List.of("스프링", "Spring"));
-        ElasticKeyword keyword4 = ElasticKeyword.create(List.of("스프링부트", "SpringBoot"));
-        ElasticKeyword keyword5 = ElasticKeyword.create(List.of("챗지피티", "ChatGPT"));
+        ElasticKeyword keyword1 = ElasticKeyword.create("JAVA");
+        ElasticKeyword keyword2 = ElasticKeyword.create("JavaScript");
+        ElasticKeyword keyword3 = ElasticKeyword.create("Spring");
+        ElasticKeyword keyword4 = ElasticKeyword.create("SpringBoot");
+        ElasticKeyword keyword5 = ElasticKeyword.create("ChatGPT");
         List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
         elasticKeywordRepository.saveAll(elasticKeywords);
 
@@ -78,11 +124,11 @@ class ElasticKeywordServiceTest {
     @DisplayName("일치하는 키워드가 없을 경우 빈 리스트를 반환한다.")
     void autocompleteKeywordNotFound() throws IOException {
         // given
-        ElasticKeyword keyword1 = ElasticKeyword.create(List.of("자바", "Java"));
-        ElasticKeyword keyword2 = ElasticKeyword.create(List.of("자바스크립트", "JavaScript"));
-        ElasticKeyword keyword3 = ElasticKeyword.create(List.of("스프링", "Spring"));
-        ElasticKeyword keyword4 = ElasticKeyword.create(List.of("스프링부트", "SpringBoot"));
-        ElasticKeyword keyword5 = ElasticKeyword.create(List.of("챗지피티", "ChatGPT"));
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링부트");
+        ElasticKeyword keyword5 = ElasticKeyword.create("챗지피티");
         List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
         elasticKeywordRepository.saveAll(elasticKeywords);
 
@@ -102,7 +148,7 @@ class ElasticKeywordServiceTest {
         // given
         List<ElasticKeyword> elasticKeywords = new ArrayList<>();
         for (int i = 0; i < n; i++) {
-            elasticKeywords.add(ElasticKeyword.create(List.of("키워드" + i)));
+            elasticKeywords.add(ElasticKeyword.create("키워드" + i));
         }
         elasticKeywordRepository.saveAll(elasticKeywords);
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/KeywordControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/KeywordControllerTest.java
@@ -37,11 +37,11 @@ class KeywordControllerTest extends SupportControllerTest {
     @DisplayName("기술블로그 키워드를 검색하면 자동완성 키워드 후보 리스트를 최대 20개 반환한다.")
     void autocompleteKeyword() throws Exception {
         // given
-        ElasticKeyword keyword1 = ElasticKeyword.create(List.of("자바", "Java"));
-        ElasticKeyword keyword2 = ElasticKeyword.create(List.of("자바스크립트", "JavaScript"));
-        ElasticKeyword keyword3 = ElasticKeyword.create(List.of("자바가 최고야", "Java is the best"));
-        ElasticKeyword keyword4 = ElasticKeyword.create(List.of("스프링", "Spring"));
-        ElasticKeyword keyword5 = ElasticKeyword.create(List.of("스프링부트", "SpringBoot"));
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("자바가 최고야");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword5 = ElasticKeyword.create("스프링부트");
         List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
         elasticKeywordRepository.saveAll(elasticKeywords);
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/KeywordControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/KeywordControllerDocsTest.java
@@ -1,6 +1,5 @@
 package com.dreamypatisiel.devdevdev.web.docs;
 
-import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.authenticationType;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -77,10 +76,8 @@ class KeywordControllerDocsTest extends SupportControllerDocsTest {
                         parameterWithName("prefix").description("검색 키워드")
                 ),
                 responseFields(
-                        fieldWithPath("resultType").type(STRING).description("응답 결과")
-                                .attributes(authenticationType()),
+                        fieldWithPath("resultType").type(STRING).description("응답 결과"),
                         fieldWithPath("datas").type(ARRAY).description("응답 데이터")
-                                .attributes(authenticationType())
                 )
         ));
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/KeywordControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/KeywordControllerDocsTest.java
@@ -48,11 +48,11 @@ class KeywordControllerDocsTest extends SupportControllerDocsTest {
     @DisplayName("기술블로그 키워드를 검색하면 자동완성 키워드 후보 리스트를 최대 20개 반환한다.")
     void autocompleteKeyword() throws Exception {
         // given
-        ElasticKeyword keyword1 = ElasticKeyword.create(List.of("자바", "Java"));
-        ElasticKeyword keyword2 = ElasticKeyword.create(List.of("자바스크립트", "JavaScript"));
-        ElasticKeyword keyword3 = ElasticKeyword.create(List.of("자바가 최고야", "Java is the best"));
-        ElasticKeyword keyword4 = ElasticKeyword.create(List.of("스프링", "Spring"));
-        ElasticKeyword keyword5 = ElasticKeyword.create(List.of("스프링부트", "SpringBoot"));
+        ElasticKeyword keyword1 = ElasticKeyword.create("자바");
+        ElasticKeyword keyword2 = ElasticKeyword.create("자바스크립트");
+        ElasticKeyword keyword3 = ElasticKeyword.create("자바가 최고야");
+        ElasticKeyword keyword4 = ElasticKeyword.create("스프링");
+        ElasticKeyword keyword5 = ElasticKeyword.create("스프링부트");
         List<ElasticKeyword> elasticKeywords = List.of(keyword1, keyword2, keyword3, keyword4, keyword5);
         elasticKeywordRepository.saveAll(elasticKeywords);
 


### PR DESCRIPTION
## 코드레벨의 변경사항
- ElasticKeyword 도큐먼트 속성 변경
  - 인덱스 설정 변경에 따른 필드 type 변경(completion → text)
  - 필드명 변경(words → keyword)
- 검색 쿼리 변경
  - multi_match 쿼리를 사용할 수 있도록 변경

## Elasticsearch에서의 변경사항
- Keywords 인덱스 설정 변경
  - `ngram_tokenizer` 를 사용한 n-gram 인덱스 생성
  - `nfc_normalizer` 를 사용한 자/모음 분리 및 초성 인덱스 생성
 
## 기능적 변경
- 검색어 자동완성 시 초성검색이 가능해졌습니다.
- 검색어 자동완성 시 자/모음이 분리되어 검색되도록 변경되었습니다.
  - AS-IS : `잡` 검색시 `자바` 조회X
  - TO-BE : `잡` 검색시에도 `자바` 조회O