### PR TITLE
[DP-339] 픽픽픽 댓글 수정 API

### DIFF
--- a/src/docs/asciidoc/api/pick-commnet/pick-comment-modify.adoc
+++ b/src/docs/asciidoc/api/pick-commnet/pick-comment-modify.adoc
@@ -1,5 +1,5 @@
 [[Pick-Comment-Modify]]
-== 픽픽픽 댓글 수정 API(POST: /devdevdev/api/v1/picks/{pickId}/comments/{pickCommentId})
+== 픽픽픽 댓글 수정 API(PATCH: /devdevdev/api/v1/picks/{pickId}/comments/{pickCommentId})
 
 * 픽픽픽 댓글을 수정한다.
 * 회원 본인이 작성한 픽픽픽 수정 할 수 있다.

--- a/src/docs/asciidoc/api/pick-commnet/pick-comment-modify.adoc
+++ b/src/docs/asciidoc/api/pick-commnet/pick-comment-modify.adoc
@@ -1,0 +1,41 @@
+[[Pick-Comment-Modify]]
+== 픽픽픽 댓글 수정 API(POST: /devdevdev/api/v1/picks/{pickId}/comments/{pickCommentId})
+
+* 픽픽픽 댓글을 수정한다.
+* 회원 본인이 작성한 픽픽픽 수정 할 수 있다.
+* 픽픽픽 공개 여부는 수정 할 수 없다.
+* 삭제된 댓글을 수정 할 수 없다.
+
+=== 정상 요청/응답
+
+==== HTTP Request
+
+include::{snippets}/modify-pick-comment/http-request.adoc[]
+
+==== HTTP Request Header Fields
+
+include::{snippets}/modify-pick-comment/request-headers.adoc[]
+
+==== HTTP Request Fields
+
+include::{snippets}/modify-pick-comment/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/modify-pick-comment/http-response.adoc[]
+
+==== HTTP Response Fields
+
+include::{snippets}/modify-pick-comment/response-fields.adoc[]
+
+=== 예외
+
+==== HTTP Response
+
+* `내용을 작성해주세요.`: 댓글(contents)을 작성하지 않는 경우(공백 이거나 빈문자열)
+* `픽픽픽 게시글이 없습니다.`: 픽픽픽 게시글이 존재하지 않거나 본인이 작성하지 않았거나 픽픽픽 댓글 삭제된 경우
+* `승인 상태가 아닌 픽픽픽에는 댓글을 수정할 수 없습니다.`: 픽픽픽이 승인 상태가 아닌 경우
+* `익명 회원은 사용할 수 없는 기능 입니다.`: 익명 회원인 경우
+* `회원을 찾을 수 없습니다.`: 회원이 존재하지 않는 경우
+
+include::{snippets}/modify-pick-comment-bind-exception/response-body.adoc[]

--- a/src/docs/asciidoc/api/pick-commnet/pick-comment-register.adoc
+++ b/src/docs/asciidoc/api/pick-commnet/pick-comment-register.adoc
@@ -35,5 +35,7 @@ include::{snippets}/register-pick-comment/response-fields.adoc[]
 * `픽픽픽 게시글이 없습니다.`: 픽픽픽 게시글이 존재하지 않는 경우
 * `승인 상태가 아닌 픽픽픽에는 댓글을 작성할 수 없습니다.`: 픽픽픽이 승인 상태가 아닌 경우
 * `투표한 픽픽픽 선택지가 존재하지 않습니다.`: 투표한 픽픽픽 선택지가 존재하지 않는 경우
+* `익명 회원은 사용할 수 없는 기능 입니다.`: 익명 회원인 경우
+* `회원을 찾을 수 없습니다.`: 회원이 존재하지 않는 경우
 
 include::{snippets}/register-pick-comment-bind-exception-pick-vote-public-is-null/response-body.adoc[]

--- a/src/docs/asciidoc/api/pick-commnet/pick-comment.adoc
+++ b/src/docs/asciidoc/api/pick-commnet/pick-comment.adoc
@@ -1,3 +1,4 @@
 = 픽픽픽 댓글
 
 include::pick-comment-register.adoc[]
+include::pick-comment-modify.adoc[]

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/PickComment.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/PickComment.java
@@ -24,7 +24,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-        @Index(name = "idx__member__pick__deleted_at", columnList = "member_id, pick_id, deletedAt")
+        @Index(name = "idx__member__pick__deleted_at", columnList = "member_id, pick_id, deletedAt"),
+        @Index(name = "idx__comment__member__pick__deleted_at", columnList = "id, member_id, pick_id, deletedAt")
 })
 public class PickComment extends BasicTime {
 
@@ -69,11 +70,13 @@ public class PickComment extends BasicTime {
 
 
     @Builder
-    private PickComment(CommentContents contents, Count blameTotalCount, Count recommendTotalCount, Member member,
+    private PickComment(CommentContents contents, Count blameTotalCount, Count recommendTotalCount, Boolean isPublic,
+                        Member member,
                         Pick pick, PickVote pickVote) {
         this.contents = contents;
         this.blameTotalCount = blameTotalCount;
         this.recommendTotalCount = recommendTotalCount;
+        this.isPublic = isPublic;
         this.member = member;
         this.pick = pick;
         this.pickVote = pickVote;
@@ -113,5 +116,9 @@ public class PickComment extends BasicTime {
 
     public void changeDeletedAt(LocalDateTime now) {
         this.deletedAt = now;
+    }
+
+    public void changeCommentContents(CommentContents contents) {
+        this.contents = contents;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/PickExceptionMessage.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/PickExceptionMessage.java
@@ -8,11 +8,12 @@ public class PickExceptionMessage {
     public static final String INVALID_PICK_OPTION_NAME_MESSAGE = "잘못된 형식의 픽픽픽 선택지 입니다.";
     public static final String INVALID_NOT_FOUND_CAN_MODIFY_PICK_MESSAGE = "수정할 수 있는 픽픽픽 게시글이 없습니다.";
     public static final String INVALID_NOT_FOUND_PICK_MESSAGE = "픽픽픽 게시글이 없습니다.";
+    public static final String INVALID_NOT_FOUND_PICK_COMMENT_MESSAGE = "픽픽픽 댓글이 없습니다.";
     public static final String INVALID_MODIFY_MEMBER_PICK_ONLY_MESSAGE = "회원 본인이 작성한 게시글만 수정할 수 있습니다.";
     public static final String INVALID_NOT_FOUND_PICK_OPTION_MESSAGE = "픽픽픽 선택지가 존재하지 않습니다.";
     public static final String INVALID_NOT_FOUND_PICK_VOTE_MESSAGE = "투표한 픽픽픽 선택지가 존재하지 않습니다.";
     public static final String INVALID_CAN_NOT_VOTE_SAME_PICK_OPTION_MESSAGE = "동일한 픽픽픽 선택지에 투표할 수 없습니다.";
     public static final String INVALID_NOT_APPROVAL_STATUS_PICK_MESSAGE = "픽픽픽 게시글 상태가 승인 상태가 아닙니다. 관리자에게 문의하세요.";
-    public static final String INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE = "승인 상태가 아닌 픽픽픽에는 댓글을 작성할 수 없습니다.";
+    public static final String INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE = "승인 상태가 아닌 픽픽픽에는 댓글을 %s할 수 없습니다.";
     public static final String INVALID_ANONYMOUS_MEMBER_ID_MESSAGE = "익명 회원 아이디를 확인해주세요.";
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/PickCommentRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/PickCommentRepository.java
@@ -1,7 +1,12 @@
 package com.dreamypatisiel.devdevdev.domain.repository.pick;
 
 import com.dreamypatisiel.devdevdev.domain.entity.PickComment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PickCommentRepository extends JpaRepository<PickComment, Long> {
+
+    @EntityGraph(attributePaths = {"pick"})
+    Optional<PickComment> findWithPickByIdAndPickIdAndMemberIdAndDeletedAtIsNull(Long id, Long pickId, Long memberId);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/PickRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/pick/PickRepository.java
@@ -15,7 +15,4 @@ public interface PickRepository extends JpaRepository<Pick, Long>, PickRepositor
     Optional<Pick> findPickWithPickOptionByIdAndMember(Long id, Member member);
 
     List<Pick> findTop1000ByContentStatusAndEmbeddingsIsNotNullOrderByCreatedAtDesc(ContentStatus contentStatus);
-
-    @EntityGraph(attributePaths = {"pickVotes"})
-    Optional<Pick> findWithPickVoteById(Long id);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickCommentService.java
@@ -37,6 +37,11 @@ public class MemberPickCommentService {
     private final PickVoteRepository pickVoteRepository;
     private final PickCommentRepository pickCommentRepository;
 
+    /**
+     * @Note: 픽픽픽 댓글을 작성한다.
+     * @Author: 장세웅
+     * @Since: 2024.08.08
+     */
     @Transactional
     public PickCommentResponse registerPickComment(Long pickId, RegisterPickCommentRequest registerPickCommentRequest,
                                                    Authentication authentication) {
@@ -82,10 +87,11 @@ public class MemberPickCommentService {
     }
 
     /**
-     * @Note: 픽픽픽 댓글 수정한다. 픽픽픽 공개 여부는 수정할 수 없다.
+     * @Note: 픽픽픽 댓글을 수정한다. 픽픽픽 공개 여부는 수정할 수 없다.
      * @Author: 장세웅
      * @Since: 2024.08.10
      */
+    @Transactional
     public PickCommentResponse modifyPickComment(Long pickCommentId, Long pickId,
                                                  ModifyPickCommentRequest modifyPickCommentRequest,
                                                  Authentication authentication) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickCommentService.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.domain.service.pick;
 
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE;
+import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_NOT_FOUND_PICK_COMMENT_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_NOT_FOUND_PICK_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.PickExceptionMessage.INVALID_NOT_FOUND_PICK_VOTE_MESSAGE;
 
@@ -16,6 +17,7 @@ import com.dreamypatisiel.devdevdev.domain.repository.pick.PickVoteRepository;
 import com.dreamypatisiel.devdevdev.domain.service.response.PickCommentResponse;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import com.dreamypatisiel.devdevdev.web.controller.pick.request.ModifyPickCommentRequest;
 import com.dreamypatisiel.devdevdev.web.controller.pick.request.RegisterPickCommentRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -26,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberPickCommentService {
+
+    public static final String MODIFY = "수정";
+    public static final String REGISTER = "작성";
 
     private final MemberProvider memberProvider;
     private final PickRepository pickRepository;
@@ -48,7 +53,9 @@ public class MemberPickCommentService {
 
         // 픽픽픽 게시글의 승인 상태가 아니면
         if (!findPick.isTrueContentStatus(ContentStatus.APPROVAL)) {
-            throw new IllegalArgumentException(INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE);
+            throw new IllegalArgumentException(
+                    String.format(INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE, REGISTER)
+            );
         }
 
         // 픽픽픽 선택지 투표 공개인 경우
@@ -72,5 +79,37 @@ public class MemberPickCommentService {
         pickCommentRepository.save(pickComment);
 
         return new PickCommentResponse(pickComment.getId());
+    }
+
+    /**
+     * @Note: 픽픽픽 댓글 수정한다. 픽픽픽 공개 여부는 수정할 수 없다.
+     * @Author: 장세웅
+     * @Since: 2024.08.10
+     */
+    public PickCommentResponse modifyPickComment(Long pickCommentId, Long pickId,
+                                                 ModifyPickCommentRequest modifyPickCommentRequest,
+                                                 Authentication authentication) {
+
+        String contents = modifyPickCommentRequest.getContents();
+
+        // 회원 조회
+        Member findMember = memberProvider.getMemberByAuthentication(authentication);
+
+        // 픽픽픽 댓글 조회(회원 본인이 댓글 작성, 삭제되지 않은 댓글)
+        PickComment findPickComment = pickCommentRepository.findWithPickByIdAndPickIdAndMemberIdAndDeletedAtIsNull(
+                        pickCommentId, pickId, findMember.getId())
+                .orElseThrow(() -> new NotFoundException(INVALID_NOT_FOUND_PICK_COMMENT_MESSAGE));
+
+        // 픽픽픽 게시글의 승인 상태가 아니면
+        if (!findPickComment.getPick().isTrueContentStatus(ContentStatus.APPROVAL)) {
+            throw new IllegalArgumentException(
+                    String.format(INVALID_NOT_APPROVAL_STATUS_PICK_COMMENT_MESSAGE, MODIFY)
+            );
+        }
+
+        // 댓글 수정
+        findPickComment.changeCommentContents(new CommentContents(contents));
+
+        return new PickCommentResponse(findPickComment.getId());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/PickCommentController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/PickCommentController.java
@@ -3,6 +3,7 @@ package com.dreamypatisiel.devdevdev.web.controller.pick;
 import com.dreamypatisiel.devdevdev.domain.service.pick.MemberPickCommentService;
 import com.dreamypatisiel.devdevdev.domain.service.response.PickCommentResponse;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import com.dreamypatisiel.devdevdev.web.controller.pick.request.ModifyPickCommentRequest;
 import com.dreamypatisiel.devdevdev.web.controller.pick.request.RegisterPickCommentRequest;
 import com.dreamypatisiel.devdevdev.web.response.BasicResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,4 +41,18 @@ public class PickCommentController {
         return ResponseEntity.ok(BasicResponse.success(pickCommentResponse));
     }
 
+    @Operation(summary = "픽픽픽 댓글 수정", description = "회원은 픽픽픽 댓글을 수정할 수 있습니다.")
+    @PatchMapping("/picks/{pickId}/comments/{pickCommentId}")
+    public ResponseEntity<BasicResponse<PickCommentResponse>> modifyPickComment(
+            @PathVariable(name = "pickId") Long pickId,
+            @PathVariable(name = "pickCommentId") Long pickCommentId,
+            @RequestBody @Validated ModifyPickCommentRequest modifyPickCommentRequest) {
+
+        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
+
+        PickCommentResponse pickCommentResponse = memberPickCommentService.modifyPickComment(pickId, pickCommentId,
+                modifyPickCommentRequest, authentication);
+
+        return ResponseEntity.ok(BasicResponse.success(pickCommentResponse));
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/request/ModifyPickCommentRequest.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/request/ModifyPickCommentRequest.java
@@ -2,10 +2,16 @@ package com.dreamypatisiel.devdevdev.web.controller.pick.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class ModifyPickCommentRequest {
 
     @NotBlank(message = "내용을 작성해주세요.")
-    private final String contents;
+    private String contents;
+
+    public ModifyPickCommentRequest(String contents) {
+        this.contents = contents;
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/request/ModifyPickCommentRequest.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/pick/request/ModifyPickCommentRequest.java
@@ -1,15 +1,11 @@
 package com.dreamypatisiel.devdevdev.web.controller.pick.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-public class RegisterPickCommentRequest {
+public class ModifyPickCommentRequest {
 
     @NotBlank(message = "내용을 작성해주세요.")
     private final String contents;
-
-    @NotNull(message = "픽픽픽 공개 여부는 필수 값 입니다.")
-    private final Boolean isPickVotePublic;
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/pick/PickCommentControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/pick/PickCommentControllerTest.java
@@ -93,8 +93,7 @@ class PickCommentControllerTest extends SupportControllerTest {
         em.flush();
         em.clear();
 
-        RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅",
-                firstPickOption.getId(), true);
+        RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅", true);
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/picks/{pickId}/comments", pick.getId())
@@ -144,7 +143,7 @@ class PickCommentControllerTest extends SupportControllerTest {
         em.clear();
 
         RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅",
-                firstPickOption.getId(), isPickVotePublic);
+                isPickVotePublic);
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/picks/{pickId}/comments", pick.getId())
@@ -194,7 +193,7 @@ class PickCommentControllerTest extends SupportControllerTest {
         em.clear();
 
         RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest(contents,
-                firstPickOption.getId(), true);
+                true);
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/picks/{pickId}/comments", pick.getId())

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickCommentControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickCommentControllerDocsTest.java
@@ -120,8 +120,7 @@ public class PickCommentControllerDocsTest extends SupportControllerDocsTest {
         em.flush();
         em.clear();
 
-        RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅",
-                firstPickOption.getId(), true);
+        RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅", true);
 
         // when // then
         ResultActions actions = mockMvc.perform(post("/devdevdev/api/v1/picks/{pickId}/comments", pick.getId())
@@ -190,7 +189,7 @@ public class PickCommentControllerDocsTest extends SupportControllerDocsTest {
         em.clear();
 
         RegisterPickCommentRequest registerPickCommentRequest = new RegisterPickCommentRequest("안녕하세웅",
-                firstPickOption.getId(), isPickVotePublic);
+                isPickVotePublic);
 
         // when // then
         ResultActions actions = mockMvc.perform(post("/devdevdev/api/v1/picks/{pickId}/comments", pick.getId())

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickCommentControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/PickCommentControllerDocsTest.java
@@ -4,6 +4,7 @@ import static com.dreamypatisiel.devdevdev.global.constant.SecurityConstant.AUTH
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -27,9 +28,11 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.Pick;
+import com.dreamypatisiel.devdevdev.domain.entity.PickComment;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOption;
 import com.dreamypatisiel.devdevdev.domain.entity.PickOptionImage;
 import com.dreamypatisiel.devdevdev.domain.entity.PickVote;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.CommentContents;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.PickOptionContents;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.Title;
@@ -39,12 +42,14 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.policy.PickPopularScorePolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
+import com.dreamypatisiel.devdevdev.domain.repository.pick.PickCommentRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionImageRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickOptionRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickVoteRepository;
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
+import com.dreamypatisiel.devdevdev.web.controller.pick.request.ModifyPickCommentRequest;
 import com.dreamypatisiel.devdevdev.web.controller.pick.request.ModifyPickOptionRequest;
 import com.dreamypatisiel.devdevdev.web.controller.pick.request.ModifyPickRequest;
 import com.dreamypatisiel.devdevdev.web.controller.pick.request.RegisterPickCommentRequest;
@@ -59,6 +64,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -82,6 +88,8 @@ public class PickCommentControllerDocsTest extends SupportControllerDocsTest {
     PickOptionImageRepository pickOptionImageRepository;
     @Autowired
     PickVoteRepository pickVoteRepository;
+    @Autowired
+    PickCommentRepository pickCommentRepository;
     @Autowired
     EntityManager em;
     @MockBean
@@ -220,6 +228,126 @@ public class PickCommentControllerDocsTest extends SupportControllerDocsTest {
                 ),
                 exceptionResponseFields()
         ));
+    }
+
+    @Test
+    @DisplayName("승인 상태이고 회원 본인이 작성한 삭제되지 않은 픽픽픽 댓글을 수정한다.")
+    void modifyPickComment() throws Exception {
+        // given
+        // 회원 생성
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        memberRepository.save(member);
+
+        // 픽픽픽 생성
+        Pick pick = createPick(new Title("픽픽픽 타이틀"), ContentStatus.APPROVAL, member);
+        pickRepository.save(pick);
+
+        // 픽픽픽 댓글 생성
+        PickComment pickComment = createPickComment(new CommentContents("안녕하세웅"), false, member, pick);
+        pickCommentRepository.save(pickComment);
+
+        em.flush();
+        em.clear();
+
+        ModifyPickCommentRequest request = new ModifyPickCommentRequest("주무세웅");
+
+        // when // then
+        ResultActions actions = mockMvc.perform(patch("/devdevdev/api/v1/picks/{pickId}/comments/{pickCommentId}",
+                        pick.getId(), pickComment.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .content(om.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // docs
+        actions.andDo(document("modify-pick-comment",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                        headerWithName(AUTHORIZATION_HEADER).optional().description("Bearer 엑세스 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("pickId").description("픽픽픽 아이디"),
+                        parameterWithName("pickCommentId").description("픽픽픽 댓글 아이디")
+                ),
+                requestFields(
+                        fieldWithPath("contents").type(STRING).description("픽픽픽 댓글 내용(최소 1자 이상 최대 1,000자 이하)")
+                ),
+                responseFields(
+                        fieldWithPath("resultType").type(STRING).description("응답 결과"),
+                        fieldWithPath("data").type(OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.pickCommentId").type(NUMBER).description("픽픽픽 댓글 아이디")
+                )
+        ));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @DisplayName("승인 상태이고 회원 본인이 작성한 삭제되지 않은 픽픽픽 댓글을 수정할 때 수정할 내용이 공백이면 예외가 발생한다.")
+    void modifyPickCommentBindException(String contents) throws Exception {
+        // given
+        // 회원 생성
+        SocialMemberDto socialMemberDto = createSocialDto("dreamy5patisiel", "꿈빛파티시엘",
+                "꿈빛파티시엘", "1234", email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        memberRepository.save(member);
+
+        // 픽픽픽 생성
+        Pick pick = createPick(new Title("픽픽픽 타이틀"), ContentStatus.APPROVAL, member);
+        pickRepository.save(pick);
+
+        // 픽픽픽 댓글 생성
+        PickComment pickComment = createPickComment(new CommentContents("안녕하세웅"), false, member, pick);
+        pickCommentRepository.save(pickComment);
+
+        em.flush();
+        em.clear();
+
+        ModifyPickCommentRequest request = new ModifyPickCommentRequest(contents);
+
+        // when // then
+        ResultActions actions = mockMvc.perform(patch("/devdevdev/api/v1/picks/{pickId}/comments/{pickCommentId}",
+                        pick.getId(), pickComment.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .content(om.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().is4xxClientError());
+
+        // docs
+        actions.andDo(document("modify-pick-comment-bind-exception",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                        headerWithName(AUTHORIZATION_HEADER).optional().description("Bearer 엑세스 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("pickId").description("픽픽픽 아이디"),
+                        parameterWithName("pickCommentId").description("픽픽픽 댓글 아이디")
+                ),
+                requestFields(
+                        fieldWithPath("contents").type(STRING).description("픽픽픽 댓글 내용(최소 1자 이상 최대 1,000자 이하)")
+                ),
+                exceptionResponseFields()
+        ));
+    }
+
+    private PickComment createPickComment(CommentContents contents, Boolean isPublic, Member member, Pick pick) {
+        PickComment pickComment = PickComment.builder()
+                .contents(contents)
+                .isPublic(isPublic)
+                .member(member)
+                .pick(pick)
+                .build();
+
+        pickComment.changePick(pick);
+
+        return pickComment;
     }
 
     private Pick createPick(Title title, ContentStatus contentStatus, Member member) {


### PR DESCRIPTION
## 📝 작업 내용
* 픽픽픽 댓글을 수정합니다.
* 회원 본인이 작성한 픽픽픽 수정 할 수 있습니다.
* 픽픽픽 공개 여부는 수정 할 수 없습니다.
* 삭제된 댓글을 수정 할 수 없습니다.
* 픽픽픽 댓글 작성 API request 에서 불필요한 pickOptionId가 제거되었습니다.