### PR TITLE
[DP-374] 기술블로그 북마크 상태값 클라의존 제거

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/LocalInitData.java
@@ -184,7 +184,7 @@ public class LocalInitData {
         List<Bookmark> bookmarks = new ArrayList<>();
         for (TechArticle techArticle : techArticles) {
             if (creatRandomBoolean()) {
-                Bookmark bookmark = Bookmark.create(member, techArticle, true);
+                Bookmark bookmark = Bookmark.create(member, techArticle);
                 bookmarks.add(bookmark);
             }
         }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Bookmark.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Bookmark.java
@@ -46,11 +46,11 @@ public class Bookmark extends BasicTime {
                 .build();
     }
 
-    public static Bookmark create(Member member, TechArticle techArticle, boolean status) {
+    public static Bookmark create(Member member, TechArticle techArticle) {
         return Bookmark.builder()
                 .member(member)
                 .techArticle(techArticle)
-                .status(status)
+                .status(true)
                 .build();
     }
 
@@ -58,8 +58,12 @@ public class Bookmark extends BasicTime {
         this.techArticle = techArticle;
     }
 
-    public void changeStatus(boolean status) {
-        this.status = status;
+    public void cancelBookmark() {
+        this.status = false;
+    }
+
+    public void registerBookmark() {
+        this.status = true;
     }
 
     public boolean isBookmarked() {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleService.java
@@ -86,7 +86,7 @@ public class GuestTechArticleService extends TechArticleCommonService implements
     }
 
     @Override
-    public BookmarkResponse updateBookmark(Long techArticleId, boolean status, Authentication authentication) {
+    public BookmarkResponse updateBookmark(Long techArticleId, Authentication authentication) {
         throw new AccessDeniedException(INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE);
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechCommentService.java
@@ -318,7 +318,6 @@ public class MemberTechCommentService {
 
         // 댓글/답글에 추천이 존재하면 toggle
         if (optionalTechCommentRecommend.isPresent()) {
-            // 추천 취소
             TechCommentRecommend techCommentRecommend = optionalTechCommentRecommend.get();
 
             // 추천 상태이면 취소
@@ -330,6 +329,7 @@ public class MemberTechCommentService {
                         techComment.getRecommendTotalCount().getCount());
             }
 
+            // 추천 상태가 아니라면 추천
             techCommentRecommend.recommend();
             techComment.incrementRecommendTotalCount();
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/TechArticleService.java
@@ -17,5 +17,5 @@ public interface TechArticleService {
 
     TechArticleDetailResponse getTechArticle(Long techArticleId, Authentication authentication);
 
-    BookmarkResponse updateBookmark(Long techArticleId, boolean status, Authentication authentication);
+    BookmarkResponse updateBookmark(Long techArticleId, Authentication authentication);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleController.java
@@ -1,13 +1,13 @@
 package com.dreamypatisiel.devdevdev.web.controller.techArticle;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.BookmarkResponse;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleService;
 import com.dreamypatisiel.devdevdev.domain.service.techArticle.TechArticleServiceStrategy;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
 import com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.BookmarkResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -62,12 +62,11 @@ public class TechArticleController {
 
     @Operation(summary = "기술블로그 북마크")
     @PostMapping("/articles/{techArticleId}/bookmark")
-    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark(@PathVariable Long techArticleId,
-                                                                          @RequestParam boolean status) {
+    public ResponseEntity<BasicResponse<BookmarkResponse>> updateBookmark(@PathVariable Long techArticleId) {
 
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        BookmarkResponse response = techArticleService.updateBookmark(techArticleId, status, authentication);
+        BookmarkResponse response = techArticleService.updateBookmark(techArticleId, authentication);
 
         return ResponseEntity.ok(BasicResponse.success(response));
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
@@ -14,13 +14,13 @@ import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.Role;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import com.dreamypatisiel.devdevdev.elastic.domain.service.ElasticsearchSupportTest;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
 import com.dreamypatisiel.devdevdev.exception.TechArticleException;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -227,10 +227,9 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
         SecurityContextHolder.setContext(securityContext);
 
         Long id = firstTechArticle.getId();
-        Boolean status = true;
 
         // when // then
-        assertThatThrownBy(() -> guestTechArticleService.updateBookmark(id, status, authentication))
+        assertThatThrownBy(() -> guestTechArticleService.updateBookmark(id, authentication))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage(INVALID_ANONYMOUS_CAN_NOT_USE_THIS_FUNCTION_MESSAGE);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
@@ -17,15 +17,15 @@ import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.domain.repository.BookmarkRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.member.MemberRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.BookmarkResponse;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
-import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import com.dreamypatisiel.devdevdev.elastic.domain.service.ElasticsearchSupportTest;
 import com.dreamypatisiel.devdevdev.exception.MemberException;
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
 import com.dreamypatisiel.devdevdev.exception.TechArticleException;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.BookmarkResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleDetailResponse;
+import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechArticleMainResponse;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -279,16 +279,15 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         Long id = firstTechArticle.getId();
-        Boolean status = true;
 
         // when
-        BookmarkResponse response = memberTechArticleService.updateBookmark(id, status, authentication);
+        BookmarkResponse response = memberTechArticleService.updateBookmark(id, authentication);
 
         // then
         assertThat(response)
                 .isNotNull()
                 .extracting(techArticleId -> response.techArticleId, updatedStatus -> response.status)
-                .containsExactly(id, status);
+                .containsExactly(id, true);
     }
 
     @Test
@@ -310,16 +309,15 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
         bookmarkRepository.save(bookmark);
 
         Long id = firstTechArticle.getId();
-        Boolean status = false;
 
         // when
-        BookmarkResponse response = memberTechArticleService.updateBookmark(id, status, authentication);
+        BookmarkResponse response = memberTechArticleService.updateBookmark(id, authentication);
 
         // then
         assertThat(response)
                 .isNotNull()
                 .extracting(techArticleId -> response.techArticleId, updatedStatus -> response.status)
-                .containsExactly(id, status);
+                .containsExactly(id, false);
     }
 
     private SocialMemberDto createSocialDto(String userId, String name, String nickName, String password, String email,

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
@@ -483,7 +483,6 @@ class TechArticleControllerTest extends SupportControllerTest {
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/articles/{id}/bookmark", id)
-                        .queryParam("status", String.valueOf(true))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -515,7 +514,6 @@ class TechArticleControllerTest extends SupportControllerTest {
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/articles/{id}/bookmark", id)
-                        .queryParam("status", String.valueOf(true))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -534,7 +532,6 @@ class TechArticleControllerTest extends SupportControllerTest {
 
         // when // then
         mockMvc.perform(post("/devdevdev/api/v1/articles/{id}/bookmark", id)
-                        .queryParam("status", String.valueOf(true))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -518,7 +518,6 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
 
         // when // then
         ResultActions actions = mockMvc.perform(post("/devdevdev/api/v1/articles/{techArticleId}/bookmark", id)
-                        .queryParam("status", String.valueOf(true))
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding(StandardCharsets.UTF_8)
                         .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
@@ -530,9 +529,6 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                 preprocessResponse(prettyPrint()),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER).optional().description("Bearer 엑세스 토큰")
-                ),
-                queryParameters(
-                        parameterWithName("status").description("북마크 상태")
                 ),
                 pathParameters(
                         parameterWithName("techArticleId").description("기술블로그 아이디")


### PR DESCRIPTION
## 📝 작업 내용
- 기술블로그 북마크 요청시 status 값으로 오던 값을 제거하고, 서버에서 값을 확인하여 toggle 하는 방식으로 변경하였습니다.
- 전체적인 로직은 '픽픽픽/기술블로그 댓글 추천' 에서의 로직과 동일합니다.

