### PR TITLE
[DP-373] 기술블로그 메인 조회시 썸네일 회사 로고 여부 isLogoImage 필드 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponse.java
@@ -19,6 +19,7 @@ public class TechArticleMainResponse {
     public final Long id;
     public final String elasticId;
     public final String thumbnailUrl;
+    public final Boolean isLogoImage;
     public final String techArticleUrl;
     public final String title;
     public final String contents;
@@ -33,7 +34,7 @@ public class TechArticleMainResponse {
     public final Float score;
 
     @Builder
-    private TechArticleMainResponse(Long id, String elasticId, String thumbnailUrl, String techArticleUrl, String title,
+    private TechArticleMainResponse(Long id, String elasticId, String thumbnailUrl, Boolean isLogoImage, String techArticleUrl, String title,
                                     String contents,
                                     CompanyResponse company, LocalDate regDate, String author, Long viewTotalCount,
                                     Long recommendTotalCount, Long commentTotalCount, Long popularScore,
@@ -41,6 +42,7 @@ public class TechArticleMainResponse {
         this.id = id;
         this.elasticId = elasticId;
         this.thumbnailUrl = thumbnailUrl;
+        this.isLogoImage = isLogoImage;
         this.techArticleUrl = techArticleUrl;
         this.title = title;
         this.contents = contents;
@@ -66,6 +68,7 @@ public class TechArticleMainResponse {
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
                 .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
+                .isLogoImage(ObjectUtils.isEmpty(elasticTechArticle.getThumbnailUrl()))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .company(companyResponse)
@@ -88,6 +91,7 @@ public class TechArticleMainResponse {
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
                 .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
+                .isLogoImage(ObjectUtils.isEmpty(elasticTechArticle.getThumbnailUrl()))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .company(companyResponse)
@@ -110,6 +114,7 @@ public class TechArticleMainResponse {
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
                 .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
+                .isLogoImage(ObjectUtils.isEmpty(elasticTechArticle.getThumbnailUrl()))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .contents(truncateString(elasticTechArticle.getContents(), CONTENTS_MAX_LENGTH))
@@ -134,6 +139,7 @@ public class TechArticleMainResponse {
                 .popularScore(techArticle.getPopularScore().getCount())
                 .elasticId(elasticTechArticle.getId())
                 .thumbnailUrl(getThumbnailUrl(elasticTechArticle, companyResponse))
+                .isLogoImage(ObjectUtils.isEmpty(elasticTechArticle.getThumbnailUrl()))
                 .techArticleUrl(elasticTechArticle.getTechArticleUrl())
                 .title(elasticTechArticle.getTitle())
                 .contents(truncateString(elasticTechArticle.getContents(), CONTENTS_MAX_LENGTH))

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsTest.java
@@ -226,6 +226,8 @@ public class MyPageControllerDocsTest extends SupportControllerDocsTest {
                                 .description("기술블로그 Url"),
                         fieldWithPath("data.content.[].thumbnailUrl").type(JsonFieldType.STRING)
                                 .description("기술블로그 썸네일 이미지"),
+                        fieldWithPath("data.content.[].isLogoImage").type(JsonFieldType.BOOLEAN)
+                                .description("썸네일 이미지의 회사 로고 여부"),
                         fieldWithPath("data.content.[].title").type(JsonFieldType.STRING).description("기술블로그 제목"),
                         fieldWithPath("data.content.[].contents").type(JsonFieldType.STRING).description("기술블로그 내용"),
                         fieldWithPath("data.content.[].company").type(JsonFieldType.OBJECT).description("기술블로그 회사"),

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -183,6 +183,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                                 .description("기술블로그 Url"),
                         fieldWithPath("data.content.[].thumbnailUrl").type(JsonFieldType.STRING)
                                 .description("기술블로그 썸네일 이미지"),
+                        fieldWithPath("data.content.[].isLogoImage").type(JsonFieldType.BOOLEAN)
+                                .description("썸네일 이미지의 회사 로고 여부"),
                         fieldWithPath("data.content.[].title").type(JsonFieldType.STRING).description("기술블로그 제목"),
                         fieldWithPath("data.content.[].contents").type(JsonFieldType.STRING).description("기술블로그 내용"),
                         fieldWithPath("data.content.[].company").type(JsonFieldType.OBJECT).description("기술블로그 회사"),

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponseTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponseTest.java
@@ -1,0 +1,101 @@
+package com.dreamypatisiel.devdevdev.web.dto.response.techArticle;
+
+import com.dreamypatisiel.devdevdev.domain.entity.Company;
+import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.CompanyName;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Count;
+import com.dreamypatisiel.devdevdev.domain.entity.embedded.Url;
+import com.dreamypatisiel.devdevdev.elastic.domain.document.ElasticTechArticle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TechArticleMainResponseTest {
+
+    @Test
+    @DisplayName("ElasticTechArticle의 썸네일 이미지가 있다면 썸네일 이미지로 설정되어야 한다.")
+    public void setThumbnailImageWhenPresent() {
+        // given
+        Company company = createCompany("꿈빛 파티시엘", "https://officialImageUrl.png",
+                "https://officialUrl.com", "https://careerUrl.com");
+
+        TechArticle techArticle = TechArticle.createTechArticle(new Url("https://example.com"), new Count(1L),
+                new Count(1L), new Count(1L), new Count(1L), null, company);
+
+        ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId", "타이틀", LocalDate.now(),
+                "내용", "http://example.com/", "설명", "http://thumbnailImage.com", "작성자",
+                company.getName().getCompanyName(), company.getId(), 0L, 0L, 0L, 0L);
+
+        CompanyResponse companyResponse = CompanyResponse.from(company);
+
+        // when
+        TechArticleMainResponse techArticleMainResponse = TechArticleMainResponse
+                .of(techArticle, elasticTechArticle, companyResponse);
+
+        // then
+        assertEquals("http://thumbnailImage.com", techArticleMainResponse.getThumbnailUrl());
+        assertFalse(techArticleMainResponse.getIsLogoImage());
+    }
+
+    @Test
+    @DisplayName("ElasticTechArticle의 썸네일 이미지가 없다면 회사 로고 이미지로 대체하고, isLogoImage가 true로 설정되어야 한다.")
+    public void setLogoImageWhenThumbnailIsAbsent() {
+        // given
+        Company company = createCompany("꿈빛 파티시엘", "https://officialImageUrl.png",
+                "https://officialUrl.com", "https://careerUrl.com");
+
+        TechArticle techArticle = TechArticle.createTechArticle(new Url("https://example.com"), new Count(1L),
+                new Count(1L), new Count(1L), new Count(1L), null, company);
+
+        ElasticTechArticle elasticTechArticle = createElasticTechArticle("elasticId", "타이틀", LocalDate.now(),
+                "내용", "http://example.com/", "설명", null, "작성자",
+                company.getName().getCompanyName(), company.getId(), 0L, 0L, 0L, 0L);
+
+        CompanyResponse companyResponse = CompanyResponse.from(company);
+
+        // when
+        TechArticleMainResponse techArticleMainResponse = TechArticleMainResponse
+                .of(techArticle, elasticTechArticle, companyResponse);
+
+        // then
+        assertEquals(company.getOfficialImageUrl(), techArticleMainResponse.getThumbnailUrl());
+        assertTrue(techArticleMainResponse.getIsLogoImage());
+    }
+
+    private static Company createCompany(String companyName, String officialImageUrl, String officialUrl,
+                                         String careerUrl) {
+        return Company.builder()
+                .name(new CompanyName(companyName))
+                .officialUrl(new Url(officialUrl))
+                .careerUrl(new Url(careerUrl))
+                .officialImageUrl(officialImageUrl)
+                .build();
+    }
+
+    private static ElasticTechArticle createElasticTechArticle(String id, String title, LocalDate regDate,
+                                                               String contents, String techArticleUrl,
+                                                               String description, String thumbnailUrl, String author,
+                                                               String company, Long companyId,
+                                                               Long viewTotalCount, Long recommendTotalCount,
+                                                               Long commentTotalCount, Long popularScore) {
+        return ElasticTechArticle.builder()
+                .id(id)
+                .title(title)
+                .regDate(regDate)
+                .contents(contents)
+                .techArticleUrl(techArticleUrl)
+                .description(description)
+                .thumbnailUrl(thumbnailUrl)
+                .author(author)
+                .company(company)
+                .companyId(companyId)
+                .viewTotalCount(viewTotalCount)
+                .recommendTotalCount(recommendTotalCount)
+                .commentTotalCount(commentTotalCount)
+                .popularScore(popularScore)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 기술블로그 메인 API or 북마크 목록 API 을 통해 기술블로그 목록을 조회할 때, 썸네일 이미지가 회사 로고로 대체되었는지 여부를 응답에 추가했습니다.

```
// 썸네일 이미지가 아티클 이미지라면 false, 회사 로고 이미지라면 true
"isLogoImage" : false, 
```

## 🔗 참고할만한 자료(선택)

- Slack: https://dreamy-patisiel.slack.com/archives/C066AN5CS4X/p1725785519416209

