### PR TITLE
[DP-420] 기술블로그 베스트댓글 조회 정책 변경(추천수 1개 이상, 부모댓글개수 필드 추가)

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechCommentRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechCommentRepository.java
@@ -21,4 +21,6 @@ public interface TechCommentRepository extends JpaRepository<TechComment, Long>,
     @EntityGraph(attributePaths = {"createdBy", "deletedBy", "techArticle"})
     List<TechComment> findWithMemberWithTechArticleByOriginParentIdInAndParentIsNotNullAndOriginParentIsNotNull(
             Set<Long> originParentIds);
+
+    Long countByTechArticleIdAndParentIsNull(Long techArticleId);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface TechCommentRepositoryCustom {
                                                             TechCommentSort techCommentSort, Pageable pageable);
 
     List<TechComment> findOriginParentTechBestCommentsByTechArticleIdAndOffset(Long techArticleId, int size);
+
+    Long countByTechArticleIdAndParentIsNull(Long techArticleId);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryCustom.java
@@ -11,6 +11,4 @@ public interface TechCommentRepositoryCustom {
                                                             TechCommentSort techCommentSort, Pageable pageable);
 
     List<TechComment> findOriginParentTechBestCommentsByTechArticleIdAndOffset(Long techArticleId, int size);
-
-    Long countByTechArticleIdAndParentIsNull(Long techArticleId);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechCommentRepositoryImpl.java
@@ -59,14 +59,6 @@ public class TechCommentRepositoryImpl implements TechCommentRepositoryCustom {
                 .fetch();
     }
 
-    @Override
-    public Long countByTechArticleIdAndParentIsNull(Long techArticleId) {
-        return query.selectFrom(techComment)
-                .where(techComment.techArticle.id.eq(techArticleId)
-                        .and(techComment.parent.isNull()))
-                .fetchCount();
-    }
-
     private BooleanExpression getCursorCondition(TechCommentSort techCommentSort, Long techCommentId) {
         if (ObjectUtils.isEmpty(techCommentId)) {
             return null;

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/GuestTechCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/GuestTechCommentService.java
@@ -6,6 +6,7 @@ import com.dreamypatisiel.devdevdev.domain.policy.TechBestCommentsPolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentSort;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.ModifyTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.RegisterTechCommentRequest;
@@ -57,9 +58,9 @@ public class GuestTechCommentService extends TechCommentCommonService implements
     }
 
     @Override
-    public SliceCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
-                                                             TechCommentSort techCommentSort, Pageable pageable,
-                                                             Authentication authentication) {
+    public SliceCommentCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
+                                                                    TechCommentSort techCommentSort, Pageable pageable,
+                                                                    Authentication authentication) {
         // 익명 회원인지 검증
         AuthenticationMemberUtils.validateAnonymousMethodCall(authentication);
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/MemberTechCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/MemberTechCommentService.java
@@ -1,10 +1,5 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle.techComment;
 
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.INVALID_CAN_NOT_RECOMMEND_DELETED_TECH_COMMENT_MESSAGE;
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.INVALID_CAN_NOT_REPLY_DELETED_TECH_COMMENT_MESSAGE;
-import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.INVALID_NOT_FOUND_TECH_COMMENT_MESSAGE;
-import static com.dreamypatisiel.devdevdev.domain.service.techArticle.techArticle.TechArticleCommonService.validateIsDeletedTechComment;
-
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.entity.TechComment;
@@ -19,18 +14,22 @@ import com.dreamypatisiel.devdevdev.domain.service.techArticle.techArticle.TechA
 import com.dreamypatisiel.devdevdev.exception.NotFoundException;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
 import com.dreamypatisiel.devdevdev.global.common.TimeProvider;
-import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
+import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.ModifyTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.RegisterTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentRecommendResponse;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentResponse;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentsResponse;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.dreamypatisiel.devdevdev.domain.exception.TechArticleExceptionMessage.*;
+import static com.dreamypatisiel.devdevdev.domain.service.techArticle.techArticle.TechArticleCommonService.validateIsDeletedTechComment;
 
 @Service
 @Transactional(readOnly = true)
@@ -223,9 +222,9 @@ public class MemberTechCommentService extends TechCommentCommonService implement
      * @Author: 유소영
      * @Since: 2024.09.05
      */
-    public SliceCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
-                                                             TechCommentSort techCommentSort, Pageable pageable,
-                                                             Authentication authentication) {
+    public SliceCommentCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
+                                                                    TechCommentSort techCommentSort, Pageable pageable,
+                                                                    Authentication authentication) {
         // 회원 조회
         Member findMember = memberProvider.getMemberByAuthentication(authentication);
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentCommonService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentCommonService.java
@@ -6,6 +6,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.TechComment;
 import com.dreamypatisiel.devdevdev.domain.policy.TechBestCommentsPolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentSort;
+import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentsResponse;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechRepliedCommentsResponse;
@@ -36,7 +37,7 @@ public class TechCommentCommonService {
      * @Author: 유소영
      * @Since: 2024.09.05
      */
-    public SliceCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
+    public SliceCommentCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
                                                              TechCommentSort techCommentSort, Pageable pageable,
                                                              @Nullable Member member) {
         // 기술블로그 최상위 댓글 조회
@@ -68,15 +69,18 @@ public class TechCommentCommonService {
 
         // 댓글이 하나도 없으면 빈 응답 리턴
         if (ObjectUtils.isEmpty(firstTechComment)) {
-            return new SliceCustom<>(techCommentsResponse, pageable, false, 0L);
+            return new SliceCommentCustom<>(techCommentsResponse, pageable, false, 0L, 0L);
         }
 
         // 기술블로그 전체 댓글/답글 개수 추출
         long originTechCommentTotalCount = firstTechComment.getTechArticle().getCommentTotalCount().getCount();
 
+        // 기술블로그 부모 댓글 개수 추출
+        long originParentTechCommentTotalCount = techCommentRepository.countByTechArticleIdAndParentIsNull(techArticleId);
+
         // 데이터 가공
-        return new SliceCustom<>(techCommentsResponse, pageable, findOriginParentTechComments.hasNext(),
-                originTechCommentTotalCount);
+        return new SliceCommentCustom<>(techCommentsResponse, pageable, findOriginParentTechComments.hasNext(),
+                originTechCommentTotalCount, originParentTechCommentTotalCount);
     }
 
     private TechCommentsResponse getTechCommentsResponse(@Nullable Member member, TechComment originParentTechComment,

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentService.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.domain.service.techArticle.techComment;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentSort;
+import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.ModifyTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.RegisterTechCommentRequest;
@@ -29,9 +30,9 @@ public interface TechCommentService {
 
     TechCommentResponse deleteTechComment(Long techArticleId, Long techCommentId, Authentication authentication);
 
-    SliceCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
-                                                      TechCommentSort techCommentSort, Pageable pageable,
-                                                      Authentication authentication);
+    SliceCommentCustom<TechCommentsResponse> getTechComments(Long techArticleId, Long techCommentId,
+                                                             TechCommentSort techCommentSort, Pageable pageable,
+                                                             Authentication authentication);
 
     TechCommentRecommendResponse recommendTechComment(Long techArticleId, Long techCommentId,
                                                       Authentication authentication);

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/SliceCommentCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/SliceCommentCustom.java
@@ -1,0 +1,17 @@
+package com.dreamypatisiel.devdevdev.web.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Getter
+public class SliceCommentCustom<T> extends SliceCustom<T> {
+
+    private final long totalOriginParentComments;
+
+    public SliceCommentCustom(List<T> content, Pageable pageable, boolean hasNext, Long totalElements, long totalOriginParentComments) {
+        super(content, pageable, hasNext, totalElements);
+        this.totalOriginParentComments = totalOriginParentComments;
+    }
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechCommentServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechCommentServiceTest.java
@@ -29,6 +29,7 @@ import com.dreamypatisiel.devdevdev.global.common.TimeProvider;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
+import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.RegisterTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentsResponse;
@@ -237,10 +238,11 @@ public class GuestTechCommentServiceTest {
         em.clear();
 
         // when
-        SliceCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
+        SliceCommentCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
                 null, TechCommentSort.OLDEST, pageable, authentication);
 
         // then
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",
@@ -528,10 +530,11 @@ public class GuestTechCommentServiceTest {
         em.clear();
 
         // when
-        SliceCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
+        SliceCommentCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
                 null, TechCommentSort.LATEST, pageable, authentication);
 
         // then
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",
@@ -694,10 +697,11 @@ public class GuestTechCommentServiceTest {
         em.clear();
 
         // when
-        SliceCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
+        SliceCommentCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
                 null, TechCommentSort.MOST_COMMENTED, pageable, authentication);
 
         // then
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",
@@ -965,10 +969,11 @@ public class GuestTechCommentServiceTest {
         em.clear();
 
         // when
-        SliceCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
+        SliceCommentCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
                 null, TechCommentSort.MOST_LIKED, pageable, authentication);
 
         // then
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",
@@ -1110,10 +1115,11 @@ public class GuestTechCommentServiceTest {
         em.clear();
 
         // when
-        SliceCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
+        SliceCommentCustom<TechCommentsResponse> response = guestTechCommentService.getTechComments(techArticleId,
                 originParentTechComment6.getId(), null, pageable, authentication);
 
         // then
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleCommentControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleCommentControllerTest.java
@@ -657,6 +657,7 @@ class TechArticleCommentControllerTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.data.sort.sorted").isBoolean())
                 .andExpect(jsonPath("$.data.sort.unsorted").isBoolean())
                 .andExpect(jsonPath("$.data.numberOfElements").isNumber())
+                .andExpect(jsonPath("$.data.totalOriginParentComments").isNumber())
                 .andExpect(jsonPath("$.data.empty").isBoolean());
     }
 

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleCommentControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleCommentControllerDocsTest.java
@@ -941,6 +941,7 @@ public class TechArticleCommentControllerDocsTest extends SupportControllerDocsT
                         fieldWithPath("data.pageable.unpaged").type(BOOLEAN).description("페이지 정보 비포함 여부"),
 
                         fieldWithPath("data.totalElements").type(NUMBER).description("전체 댓글 수"),
+                        fieldWithPath("data.totalOriginParentComments").type(NUMBER).description("전체 부모 댓글 수"),
                         fieldWithPath("data.first").type(BOOLEAN).description("현재 페이지가 첫 페이지 여부"),
                         fieldWithPath("data.last").type(BOOLEAN).description("현재 페이지가 마지막 페이지 여부"),
                         fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),


### PR DESCRIPTION
## 📝 작업 내용
- 기술블로그 베스트댓글 조회 정책 변경
  - 추천수 1개 이상일 경우에만 조회되도록 조건 추가
  - 댓글 조회시 부모댓글개수 필드(totalOriginParentComments) 추가

## 🔗 참고할만한 자료(선택)

- [관련 Slack](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1731221271199979?thread_ts=1730961402.999999&cid=C076TT1ASNB) 

## 💬 리뷰 요구사항(선택)

- 카운트 쿼리가 잘 나가는지, 추천수 개수 조건절 확인 부탁드립니다!ㅎㅎ