### PR TITLE
[DP-420] fix(techComment): 삭제된 댓글은 부모 댓글 카운트 제외

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechCommentRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechCommentRepository.java
@@ -22,5 +22,5 @@ public interface TechCommentRepository extends JpaRepository<TechComment, Long>,
     List<TechComment> findWithMemberWithTechArticleByOriginParentIdInAndParentIsNotNullAndOriginParentIsNotNull(
             Set<Long> originParentIds);
 
-    Long countByTechArticleIdAndParentIsNull(Long techArticleId);
+    Long countByTechArticleIdAndOriginParentIsNullAndParentIsNullAndDeletedAtIsNull(Long techArticleId);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentCommonService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techComment/TechCommentCommonService.java
@@ -7,7 +7,6 @@ import com.dreamypatisiel.devdevdev.domain.policy.TechBestCommentsPolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechCommentSort;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
-import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentsResponse;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechRepliedCommentsResponse;
 import java.util.Collections;
@@ -76,7 +75,7 @@ public class TechCommentCommonService {
         long originTechCommentTotalCount = firstTechComment.getTechArticle().getCommentTotalCount().getCount();
 
         // 기술블로그 부모 댓글 개수 추출
-        long originParentTechCommentTotalCount = techCommentRepository.countByTechArticleIdAndParentIsNull(techArticleId);
+        long originParentTechCommentTotalCount = techCommentRepository.countByTechArticleIdAndOriginParentIsNullAndParentIsNullAndDeletedAtIsNull(techArticleId);
 
         // 데이터 가공
         return new SliceCommentCustom<>(techCommentsResponse, pageable, findOriginParentTechComments.hasNext(),

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechCommentServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechCommentServiceTest.java
@@ -1104,6 +1104,8 @@ public class GuestTechCommentServiceTest {
         TechComment originParentTechComment6 = createMainTechComment(new CommentContents("최상위 댓글6"), member,
                 techArticle, new Count(0L), new Count(0L), new Count(0L));
 
+        originParentTechComment6.changeDeletedAt(LocalDateTime.now(), member);
+
         techCommentRepository.saveAll(List.of(
                 originParentTechComment1, originParentTechComment2, originParentTechComment3,
                 originParentTechComment4, originParentTechComment5, originParentTechComment6
@@ -1119,7 +1121,7 @@ public class GuestTechCommentServiceTest {
                 originParentTechComment6.getId(), null, pageable, authentication);
 
         // then
-        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(5L); // 삭제된 댓글은 카운트하지 않는다
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechCommentServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechCommentServiceTest.java
@@ -37,7 +37,6 @@ import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCommentCustom;
-import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.ModifyTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.request.techArticle.RegisterTechCommentRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechCommentRecommendResponse;
@@ -47,6 +46,7 @@ import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.TechRepliedComm
 import com.dreamypatisiel.devdevdev.web.dto.util.CommonResponseUtil;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
@@ -1741,6 +1741,8 @@ public class MemberTechCommentServiceTest {
         TechComment originParentTechComment6 = createMainTechComment(new CommentContents("최상위 댓글6"), member,
                 techArticle, new Count(0L), new Count(0L), new Count(0L));
 
+        originParentTechComment6.changeDeletedAt(LocalDateTime.now(), member);
+
         techCommentRepository.saveAll(List.of(
                 originParentTechComment1, originParentTechComment2, originParentTechComment3,
                 originParentTechComment4, originParentTechComment5, originParentTechComment6
@@ -1756,7 +1758,7 @@ public class MemberTechCommentServiceTest {
                 originParentTechComment6.getId(), null, pageable, authentication);
 
         // then
-        assertThat(response.getTotalOriginParentComments()).isEqualTo(6L);
+        assertThat(response.getTotalOriginParentComments()).isEqualTo(5L); // 삭제된 댓글은 카운트하지 않는다
         assertThat(response).hasSizeLessThanOrEqualTo(pageable.getPageSize())
                 .extracting(
                         "techCommentId",

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleCommentControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleCommentControllerDocsTest.java
@@ -941,7 +941,7 @@ public class TechArticleCommentControllerDocsTest extends SupportControllerDocsT
                         fieldWithPath("data.pageable.unpaged").type(BOOLEAN).description("페이지 정보 비포함 여부"),
 
                         fieldWithPath("data.totalElements").type(NUMBER).description("전체 댓글 수"),
-                        fieldWithPath("data.totalOriginParentComments").type(NUMBER).description("전체 부모 댓글 수"),
+                        fieldWithPath("data.totalOriginParentComments").type(NUMBER).description("삭제 되지 않은 최상위 댓글 수"),
                         fieldWithPath("data.first").type(BOOLEAN).description("현재 페이지가 첫 페이지 여부"),
                         fieldWithPath("data.last").type(BOOLEAN).description("현재 페이지가 마지막 페이지 여부"),
                         fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),


### PR DESCRIPTION
## 📝 작업 내용
- `totalOriginParentComments` 삭제된 댓글은 카운트에서 제외되도록 수정

## 🔗 참고할만한 자료(선택)
- [관련 Slack](https://dreamy-patisiel.slack.com/archives/C076TT1ASNB/p1731430481937249?thread_ts=1730961402.999999&cid=C076TT1ASNB)

## 💬 리뷰 요구사항(선택)
