### PR TITLE
[DP-452] fix: 일반회원 픽픽픽 작성시 자동 승인

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Pick.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Pick.java
@@ -125,12 +125,13 @@ public class Pick extends BasicTime {
         pick.popularScore = Count.defaultCount();
         pick.blameTotalCount = Count.defaultCount();
         pick.author = author;
-        pick.contentStatus = getDefaultContentStatusByMemberRole(member);
+        pick.contentStatus = ContentStatus.APPROVAL;
         pick.member = member;
 
         return pick;
     }
 
+    @Deprecated // 신고 기능 추가로 인한 삭제
     private static ContentStatus getDefaultContentStatusByMemberRole(Member member) {
         if (member.isAdmin()) {
             return ContentStatus.APPROVAL;

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/pick/MemberPickServiceTest.java
@@ -479,7 +479,7 @@ class MemberPickServiceTest {
     }
 
     @Test
-    @DisplayName("일반 회원이 픽픽픽을 작성하면 픽픽픽은 대기(READY) 상태이다.")
+    @DisplayName("일반 회원이 픽픽픽을 작성하면 픽픽픽은 승인(APPROVAL) 상태이다.")
     void registerPickRoleUser() {
         // given
         SocialMemberDto socialMemberDto = createSocialDto(userId, name, nickname, password, email, socialType, role);
@@ -524,7 +524,7 @@ class MemberPickServiceTest {
         assertAll(
                 () -> assertThat(findPick.getTitle()).isEqualTo(new Title("나의 픽픽픽")),
                 () -> assertThat(findPick.getAuthor()).isEqualTo(member.getName()),
-                () -> assertThat(findPick.getContentStatus()).isEqualTo(ContentStatus.READY),
+                () -> assertThat(findPick.getContentStatus()).isEqualTo(ContentStatus.APPROVAL),
                 () -> assertThat(findPick.getPickOptions()).hasSize(2)
                         .extracting("title", "contents")
                         .containsAnyOf(


### PR DESCRIPTION
## 📝 작업 내용
- 픽픽픽 게시글/댓글 신고 기능이 추가됨에 따라, 일반회원이더라도 픽픽픽 작성시 승인 절차를 거치지 않고 바로 승인되도록 수정

## 💬 리뷰 요구사항(선택)
- getDefaultContentStatusByMemberRole() 메서드를 우선 Deprecate 하긴 했는데, 완전히 제거해도 된다면 제거하는 것이 좋을 것 같기도 합니다!