### PR TITLE
[DP-447] fix: GA 값 없을 경우 대응

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/util/TechArticleResponseUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/util/TechArticleResponseUtils.java
@@ -25,6 +25,10 @@ public class TechArticleResponseUtils {
     }
 
     public static boolean isRecommendedByAnonymousMember(TechArticle techArticle, AnonymousMember anonymousMember) {
+        if(anonymousMember == null) {
+            return false;
+        }
+
         Optional<TechArticleRecommend> recommends = techArticle.getRecommends().stream()
                 .filter(recommend -> recommend.getAnonymousMember().isEqualAnonymousMemberId(anonymousMember.getId()))
                 .findAny();


### PR DESCRIPTION
## 📝 작업 내용

- 기술블로그 상세를 조회할 때, GA값이 없어 익명회원이 null인 상태로 추천여부 조회시 생기는 NPE 방지

## 🔗 참고할만한 자료(선택)
- [관련 슬랙](https://dreamy-patisiel.slack.com/archives/C066AN5CS4X/p1736079682237059)