### PR TITLE
[DP-464] bugfix: 회원/익명회원의 추천 여부 조회 메서드 -> 해당 추천의 추천자가 회원/익명회원인지 필터링하는 로직 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/TechArticleRecommend.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/TechArticleRecommend.java
@@ -70,4 +70,12 @@ public class TechArticleRecommend extends BasicTime {
     public boolean isRecommended() {
         return this.status;
     }
+
+    public boolean isAnonymousMemberNotNull() {
+        return this.anonymousMember != null;
+    }
+    public boolean isMemberNotNull() {
+        return this.member != null;
+    }
+
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/util/TechArticleResponseUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/util/TechArticleResponseUtils.java
@@ -18,7 +18,9 @@ public class TechArticleResponseUtils {
 
     public static boolean isRecommendedByMember(TechArticle techArticle, Member member) {
         Optional<TechArticleRecommend> recommends = techArticle.getRecommends().stream()
-                .filter(recommend -> recommend.getMember().isEqualsId(member.getId()))
+                .filter(recommend ->
+                        recommend.isMemberNotNull()
+                        && recommend.getMember().isEqualsId(member.getId()))
                 .findAny();
 
         return recommends.map(TechArticleRecommend::isRecommended).orElse(false);
@@ -30,7 +32,9 @@ public class TechArticleResponseUtils {
         }
 
         Optional<TechArticleRecommend> recommends = techArticle.getRecommends().stream()
-                .filter(recommend -> recommend.getAnonymousMember().isEqualAnonymousMemberId(anonymousMember.getId()))
+                .filter(recommend ->
+                        recommend.isAnonymousMemberNotNull()
+                        && recommend.getAnonymousMember().isEqualAnonymousMemberId(anonymousMember.getId()))
                 .findAny();
 
         return recommends.map(TechArticleRecommend::isRecommended).orElse(false);


### PR DESCRIPTION
## 📝 작업 내용
- 기술블로그 상세 조회 시, 회원/익명회원의 해당 글 추천여부를 확인하는 로직이 있는데, 이때 각 추천 entity의 추천자(회원 or 익명회원)에 따라 필터링이 필요하여 이부분 적용했습니다.

## 🔗 참고할만한 자료(선택)

## 💬 리뷰 요구사항(선택)
