### PR TITLE
fix: 기술블로그 추천 API 응답에 총 추천수 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/GuestTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/GuestTechArticleService.java
@@ -129,7 +129,7 @@ public class GuestTechArticleService extends TechArticleCommonService implements
                 techArticle.decrementRecommendTotalCount();
                 techArticle.changePopularScore(techArticlePopularScorePolicy);
 
-                return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+                return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
             }
 
             // 추천 상태가 아니라면 추천
@@ -139,7 +139,7 @@ public class GuestTechArticleService extends TechArticleCommonService implements
             techArticle.incrementRecommendTotalCount();
             techArticle.changePopularScore(techArticlePopularScorePolicy);
 
-            return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+            return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
         }
 
         // 추천 생성
@@ -150,7 +150,7 @@ public class GuestTechArticleService extends TechArticleCommonService implements
         techArticle.incrementRecommendTotalCount();
         techArticle.changePopularScore(techArticlePopularScorePolicy);
 
-        return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+        return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
     }
 
     /**

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/MemberTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/MemberTechArticleService.java
@@ -150,7 +150,7 @@ public class MemberTechArticleService extends TechArticleCommonService implement
                 techArticle.decrementRecommendTotalCount();
                 techArticle.changePopularScore(techArticlePopularScorePolicy);
 
-                return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+                return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
             }
 
             // 추천 상태가 아니라면 추천
@@ -160,7 +160,7 @@ public class MemberTechArticleService extends TechArticleCommonService implement
             techArticle.incrementRecommendTotalCount();
             techArticle.changePopularScore(techArticlePopularScorePolicy);
 
-            return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+            return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
         }
 
         // 추천 생성
@@ -172,7 +172,7 @@ public class MemberTechArticleService extends TechArticleCommonService implement
 
         techArticleRecommendRepository.save(techArticleRecommend);
 
-        return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended());
+        return new TechArticleRecommendResponse(techArticle.getId(), techArticleRecommend.isRecommended(), techArticle.getRecommendTotalCount().getCount());
     }
 
     /**

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleRecommendResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleRecommendResponse.java
@@ -7,9 +7,11 @@ public class TechArticleRecommendResponse {
 
     public final Long techArticleId;
     public final Boolean status;
+    public final Long recommendTotalCount;
 
-    public TechArticleRecommendResponse(Long techArticleId, Boolean status) {
+    public TechArticleRecommendResponse(Long techArticleId, Boolean status, Long recommendTotalCount) {
         this.techArticleId = techArticleId;
         this.status = status;
+        this.recommendTotalCount = recommendTotalCount;
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/GuestTechArticleServiceTest.java
@@ -310,6 +310,7 @@ class GuestTechArticleServiceTest extends ElasticsearchSupportTest {
                 .satisfies(response -> {
                     assertThat(response.getTechArticleId()).isEqualTo(techArticleId);
                     assertThat(response.getStatus()).isTrue();
+                    assertThat(response.getRecommendTotalCount()).isEqualTo(recommendTotalCount.getCount() + 1);
                 });
 
         TechArticle techArticle = techArticleRepository.findById(techArticleId).get();

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/MemberTechArticleServiceTest.java
@@ -468,6 +468,7 @@ class MemberTechArticleServiceTest extends ElasticsearchSupportTest {
                 .satisfies(response -> {
                     assertThat(response.getTechArticleId()).isEqualTo(techArticleId);
                     assertThat(response.getStatus()).isFalse();
+                    assertThat(response.getRecommendTotalCount()).isEqualTo(recommendTotalCount.getCount() - 1);
                 });
 
         TechArticle techArticle = techArticleRepository.findById(techArticleId).get();

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
@@ -573,7 +573,9 @@ class TechArticleControllerTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.data").isNotEmpty())
                 .andExpect(jsonPath("$.data").isMap())
                 .andExpect(jsonPath("$.data.techArticleId").isNumber())
-                .andExpect(jsonPath("$.data.status").isBoolean());
+                .andExpect(jsonPath("$.data.status").isBoolean())
+                .andExpect(jsonPath("$.data.recommendTotalCount").isNumber());
+
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -592,7 +592,8 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
 
                         fieldWithPath("data.techArticleId").type(JsonFieldType.NUMBER).description("기술블로그 아이디"),
-                        fieldWithPath("data.status").type(JsonFieldType.BOOLEAN).description("추천 상태")
+                        fieldWithPath("data.status").type(JsonFieldType.BOOLEAN).description("추천 상태"),
+                        fieldWithPath("data.recommendTotalCount").type(JsonFieldType.NUMBER).description("기술블로그 총 추천수")
                 )
         ));
     }


### PR DESCRIPTION
## 📝 작업 내용
- 기술블로그 추천 API 응답에 총 추천수(recommendTotalCount) 추가
- [관련슬랙](https://dreamy-patisiel.slack.com/archives/C07KGP2106R/p1737039530068359)
