### PR TITLE
feat(notification): 알림 일괄 삭제 API

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/notification/NotificationRepository.java
@@ -13,4 +13,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findAllByMemberId(Long memberId);
 
     Long countByMemberAndIsReadIsFalse(Member member);
+
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/notification/NotificationService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/notification/NotificationService.java
@@ -367,4 +367,17 @@ public class NotificationService {
         // 회원이 읽지 않은 알림 개수 조회
         return notificationRepository.countByMemberAndIsReadFalse(findMember);
     }
+
+    /**
+     * @Note: 회원의 모든 알림 삭제
+     * @Author: 유소영
+     */
+    @Transactional
+    public void deleteAllByMember(Authentication authentication) {
+        // 회원 조회
+        Member findMember = memberProvider.getMemberByAuthentication(authentication);
+
+        // 회원의 모든 알림 삭제
+        notificationRepository.deleteAllByMember(findMember);
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/test/TestController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/test/TestController.java
@@ -1,9 +1,14 @@
 package com.dreamypatisiel.devdevdev.test;
 
 import com.dreamypatisiel.devdevdev.domain.repository.pick.PickRepository;
+import com.dreamypatisiel.devdevdev.domain.service.notification.NotificationService;
+import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
 import com.dreamypatisiel.devdevdev.openai.embeddings.EmbeddingRequestHandler;
 import com.dreamypatisiel.devdevdev.openai.embeddings.EmbeddingsService;
 import java.util.List;
+
+import com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +33,16 @@ public class TestController {
     private final EmbeddingRequestHandler embeddingRequestHandler;
     private final EmbeddingsService embeddingsService;
     private final PickRepository pickRepository;
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 제거", description = "회원에게 생성된 모든 알림을 제거")
+    @DeleteMapping("/notifications")
+    @Profile("dev")
+    public ResponseEntity<com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse<Void>> delete() {
+        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
+        notificationService.deleteAllByMember(authentication);
+        return ResponseEntity.ok(com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse.success());
+    }
 
     @GetMapping("/members")
     public BasicResponse<Member> getMembers() {

--- a/src/main/java/com/dreamypatisiel/devdevdev/test/TestController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/test/TestController.java
@@ -37,7 +37,6 @@ public class TestController {
 
     @Operation(summary = "알림 제거", description = "회원에게 생성된 모든 알림을 제거")
     @DeleteMapping("/notifications")
-    @Profile("dev")
     public ResponseEntity<com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse<Void>> delete() {
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
         notificationService.deleteAllByMember(authentication);

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationController.java
@@ -25,8 +25,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -117,15 +115,6 @@ public class NotificationController {
         // 알림 발행
         notificationService.publish(NotificationType.valueOf(channel), publishTechArticleRequest);
 
-        return ResponseEntity.ok(BasicResponse.success());
-    }
-
-    // TODO: 개발용 API -> 추후 제거 필요
-    @Operation(summary = "알림 제거", description = "회원에게 생성된 모든 알림을 제거")
-    @DeleteMapping("/notifications")
-    public ResponseEntity<BasicResponse<Void>> delete() {
-        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        notificationService.deleteAllByMember(authentication);
         return ResponseEntity.ok(BasicResponse.success());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationController.java
@@ -119,4 +119,13 @@ public class NotificationController {
 
         return ResponseEntity.ok(BasicResponse.success());
     }
+
+    // TODO: 개발용 API -> 추후 제거 필요
+    @Operation(summary = "알림 제거", description = "회원에게 생성된 모든 알림을 제거")
+    @DeleteMapping("/notifications")
+    public ResponseEntity<BasicResponse<Void>> delete() {
+        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
+        notificationService.deleteAllByMember(authentication);
+        return ResponseEntity.ok(BasicResponse.success());
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 회원에 대해 생성된 알림 일괄 제거 API (개발용)

## 🔗 참고할만한 자료(선택)
- [관련 스레드](https://dreamy-patisiel.slack.com/archives/C066AN5CS4X/p1746167540519839)

## 💬 리뷰 요구사항(선택)
- 개발용이므로 문서를 따로 작성하진 않았습니다..!
