### PR TITLE
[DP-518] SSE 하트비트 간헐적으로 안오는 이슈

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/SseEmitterRepository.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/SseEmitterRepository.java
@@ -26,4 +26,8 @@ public class SseEmitterRepository {
     public Collection<SseEmitter> findAll() {
         return sseEmitters.values();
     }
+
+    public boolean existByMember(Member member) {
+        return sseEmitters.containsKey(member.getId());
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/notification/NotificationService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/notification/NotificationService.java
@@ -68,7 +68,6 @@ public class NotificationService {
         return new SseEmitter(timeout);
     }
 
-
     /**
      * @param notificationId 알림 ID
      * @param authentication 회원 정보
@@ -264,6 +263,13 @@ public class NotificationService {
     }
 
     private SseEmitter addClient(Member findMember) {
+        // 구독자 존재 여부 확인
+        boolean isExists = sseEmitterRepository.existByMember(findMember);
+
+        if (isExists) {
+            return sseEmitterRepository.findByMemberId(findMember);
+        }
+
         // 구독자 생성
         SseEmitter sseEmitter = createSseEmitter(TIMEOUT);
         sseEmitterRepository.save(findMember, sseEmitter);


### PR DESCRIPTION
> 제목 : [(Jira issue 번호)] 작업명
>
> ex) [DP-123] pull request template 작성
(확인 후 지워주세요)

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

- [ ] 기존 SSE 인스턴스가 있는지 확인하는 로직 추가
  - 기존 SSE 인스턴스가 있으면 해당 인스턴스 반환
  - SSE 인스턴스가 없으면 새롭게 생성

## 🔗 참고할만한 자료(선택)

> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요

- [관련 스레드](https://dreamy-patisiel.slack.com/archives/C0673T3JFJM/p1746441286283529)

## 💬 리뷰 요구사항(선택)
- 재연결 시 SSE를 새롭게 생성해서 발생하는 문제라고 생각해서 👆위처럼 코드 작성 했습니다.
