### PR TITLE
[DP-520] fix: 구독 가능한 기업 목록 - 기업명 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/subscription/SubscriableCompanyResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/subscription/SubscriableCompanyResponse.java
@@ -7,12 +7,14 @@ import lombok.Data;
 @Data
 public class SubscriableCompanyResponse {
     private final Long companyId;
+    private final String companyName;
     private final String companyImageUrl;
     private final Boolean isSubscribed;
 
     @Builder
-    public SubscriableCompanyResponse(Long companyId, String companyImageUrl, Boolean isSubscribed) {
+    public SubscriableCompanyResponse(Long companyId, String companyName, String companyImageUrl, Boolean isSubscribed) {
         this.companyId = companyId;
+        this.companyName = companyName;
         this.companyImageUrl = companyImageUrl;
         this.isSubscribed = isSubscribed;
     }
@@ -20,6 +22,7 @@ public class SubscriableCompanyResponse {
     public static SubscriableCompanyResponse create(Company company) {
         return SubscriableCompanyResponse.builder()
                 .companyId(company.getId())
+                .companyName(company.getName().getCompanyName())
                 .companyImageUrl(company.getOfficialImageUrl().getUrl())
                 .isSubscribed(false)
                 .build();
@@ -28,6 +31,7 @@ public class SubscriableCompanyResponse {
     public static SubscriableCompanyResponse createWithIsSubscribed(Company company, Boolean isSubscribed) {
         return SubscriableCompanyResponse.builder()
                 .companyId(company.getId())
+                .companyName(company.getName().getCompanyName())
                 .companyImageUrl(company.getOfficialImageUrl().getUrl())
                 .isSubscribed(isSubscribed)
                 .build();

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/subscription/SubscriptionControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/subscription/SubscriptionControllerTest.java
@@ -78,7 +78,7 @@ class SubscriptionControllerTest extends SupportControllerTest {
     @DisplayName("구독 가능한 기업 목록을 조회한다.")
     void getSubscriptions() throws Exception {
         // given
-        SubscriableCompanyResponse response = new SubscriableCompanyResponse(1L,
+        SubscriableCompanyResponse response = new SubscriableCompanyResponse(1L, "트이다",
                 "https://www.teuida.net/public/src/img/teuida_logo.png", true);
         given(memberSubscriptionService.getSubscribableCompany(any(), anyLong(), any()))
                 .willReturn(new SliceImpl<>(List.of(response), PageRequest.of(0, 20), false));
@@ -95,6 +95,7 @@ class SubscriptionControllerTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.data").isNotEmpty())
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content.[0].companyId").isNumber())
+                .andExpect(jsonPath("$.data.content.[0].companyName").isString())
                 .andExpect(jsonPath("$.data.content.[0].companyImageUrl").isString())
                 .andExpect(jsonPath("$.data.content.[0].isSubscribed").isBoolean())
                 .andExpect(jsonPath("$.data.pageable").isNotEmpty())

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/SubscriptionControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/SubscriptionControllerDocsTest.java
@@ -214,7 +214,7 @@ class SubscriptionControllerDocsTest extends SupportControllerDocsTest {
     @DisplayName("구독 가능한 기업 목록을 조회한다.")
     void getSubscriptions() throws Exception {
         // given
-        SubscriableCompanyResponse response = new SubscriableCompanyResponse(1L,
+        SubscriableCompanyResponse response = new SubscriableCompanyResponse(1L, "트이다",
                 "https://www.teuida.net/public/src/img/teuida_logo.png", true);
         given(memberSubscriptionService.getSubscribableCompany(any(), anyLong(), any()))
                 .willReturn(new SliceImpl<>(List.of(response), PageRequest.of(0, 20), false));
@@ -247,6 +247,7 @@ class SubscriptionControllerDocsTest extends SupportControllerDocsTest {
 
                         fieldWithPath("data.content").type(ARRAY).description("구독 가능한 기업 목록 메인 배열"),
                         fieldWithPath("data.content[].companyId").type(NUMBER).description("기업 아이디"),
+                        fieldWithPath("data.content[].companyName").type(STRING).description("기업명"),
                         fieldWithPath("data.content[].companyImageUrl").type(STRING).description("기업 로고 이미지 url"),
                         fieldWithPath("data.content[].isSubscribed").type(JsonFieldType.BOOLEAN)
                                 .description("회원의 구독 여부"),


### PR DESCRIPTION
## 📝 작업 내용
- 구독 가능한 기업 목록 (GET /subscriptions/companies) 응답값에 기업명을 추가했습니다.
- [관련스레드](https://dreamy-patisiel.slack.com/archives/C066AN5CS4X/p1746759231745469)

## 🔗 참고할만한 자료(선택)

## 💬 리뷰 요구사항(선택)
