### PR TITLE
[DP-535] 닉네임 변경 API

### DIFF
--- a/src/docs/asciidoc/api/mypage/change-nickname.adoc
+++ b/src/docs/asciidoc/api/mypage/change-nickname.adoc
@@ -19,3 +19,4 @@ include::{snippets}/change-nickname/response-fields.adoc[]
 === 예외
 ==== HTTP Response
 include::{snippets}/not-found-member-exception/response-body.adoc[]
+include::{snippets}/change-nickname-within-24hours-exception/response-body.adoc[]

--- a/src/docs/asciidoc/api/mypage/change-nickname.adoc
+++ b/src/docs/asciidoc/api/mypage/change-nickname.adoc
@@ -1,0 +1,21 @@
+[[ChangeNickname]]
+== 닉네임 변경 API(PATCH: /devdevdev/api/v1/mypage/nickname)
+* 회원은 닉네임을 변경할 수 있다.
+* 비회원은 닉네임을 변경할 수 없다.
+
+=== 정상 요청/응답
+==== HTTP Request
+include::{snippets}/change-nickname/http-request.adoc[]
+==== HTTP Request Header Fields
+include::{snippets}/change-nickname/request-headers.adoc[]
+==== HTTP Request Fields
+include::{snippets}/change-nickname/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/change-nickname/http-response.adoc[]
+==== HTTP Response Fields
+include::{snippets}/change-nickname/response-fields.adoc[]
+
+=== 예외
+==== HTTP Response
+include::{snippets}/not-found-member-exception/response-body.adoc[]

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -187,4 +187,8 @@ public class Member extends BasicTime {
         this.isDeleted = true;
         this.deletedAt = now;
     }
+
+    public void changeNickname(String nickname) {
+        this.nickname = new Nickname(nickname);
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -95,6 +96,8 @@ public class Member extends BasicTime {
     private Boolean isDeleted;
 
     private LocalDateTime deletedAt;
+
+    private LocalDateTime nicknameUpdatedAt;
 
     @OneToMany(mappedBy = "member")
     private List<InterestedCompany> interestedCompanies = new ArrayList<>();
@@ -188,7 +191,13 @@ public class Member extends BasicTime {
         this.deletedAt = now;
     }
 
-    public void changeNickname(String nickname) {
+    public void changeNickname(String nickname, LocalDateTime now) {
         this.nickname = new Nickname(nickname);
+        this.nicknameUpdatedAt = now;
+    }
+
+    public boolean isAvailableToChangeNickname() {
+        return nicknameUpdatedAt == null
+                || ChronoUnit.HOURS.between(nicknameUpdatedAt, LocalDateTime.now()) >= 24;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/NicknameExceptionMessage.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/exception/NicknameExceptionMessage.java
@@ -1,0 +1,5 @@
+package com.dreamypatisiel.devdevdev.domain.exception;
+
+public class NicknameExceptionMessage {
+    public static final String NICKNAME_CHANGE_RATE_LIMIT_MESSAGE = "닉네임은 24시간에 한 번만 변경할 수 있습니다.";
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -286,4 +286,15 @@ public class MemberService {
 
         return new SliceCustom<>(subscribedCompanyResponses, pageable, subscribedCompanies.getTotalElements());
     }
+
+    /**
+     * @Note: 유저의 닉네임을 변경합니다.
+     * @Author: 유소영
+     * @Since: 2025.07.03
+     */
+    @Transactional
+    public void changeNickname(String nickname, Authentication authentication) {
+        Member member = memberProvider.getMemberByAuthentication(authentication);
+        member.changeNickname(nickname);
+    }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -298,10 +298,10 @@ public class MemberService {
     public void changeNickname(String nickname, Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
-        if (member.isAvailableToChangeNickname()) {
-            member.changeNickname(nickname, timeProvider.getLocalDateTimeNow());
-        } else {
+        if (!member.isAvailableToChangeNickname()) {
             throw new NicknameException(NICKNAME_CHANGE_RATE_LIMIT_MESSAGE);
         }
+
+        member.changeNickname(nickname, timeProvider.getLocalDateTimeNow());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/exception/ApiControllerAdvice.java
@@ -5,13 +5,7 @@ import static com.dreamypatisiel.devdevdev.web.controller.exception.SystemErrorC
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
-import com.dreamypatisiel.devdevdev.exception.ImageFileException;
-import com.dreamypatisiel.devdevdev.exception.InternalServerException;
-import com.dreamypatisiel.devdevdev.exception.MemberException;
-import com.dreamypatisiel.devdevdev.exception.NotFoundException;
-import com.dreamypatisiel.devdevdev.exception.PickOptionImageNameException;
-import com.dreamypatisiel.devdevdev.exception.TokenInvalidException;
-import com.dreamypatisiel.devdevdev.exception.TokenNotFoundException;
+import com.dreamypatisiel.devdevdev.exception.*;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse;
@@ -98,6 +92,12 @@ public class ApiControllerAdvice {
     public ResponseEntity<BasicResponse<Object>> memberException(MemberException e) {
         return new ResponseEntity<>(BasicResponse.fail(e.getMessage(), HttpStatus.NOT_FOUND.value()),
                 HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NicknameException.class)
+    public ResponseEntity<BasicResponse<Object>> nicknameException(NicknameException e) {
+        return new ResponseEntity<>(BasicResponse.fail(e.getMessage(), HttpStatus.BAD_REQUEST.value()),
+                HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/member/MypageController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/member/MypageController.java
@@ -8,6 +8,7 @@ import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.request.comment.MyWrittenCommentRequest;
+import com.dreamypatisiel.devdevdev.web.dto.request.member.ChangeNicknameRequest;
 import com.dreamypatisiel.devdevdev.web.dto.request.member.RecordMemberExitSurveyAnswerRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.BasicResponse;
 import com.dreamypatisiel.devdevdev.web.dto.response.comment.MyWrittenCommentResponse;
@@ -30,6 +31,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -141,5 +143,15 @@ public class MypageController {
     public ResponseEntity<BasicResponse<String>> getRandomNickname() {
         String response = memberNicknameDictionaryService.createRandomNickname();
         return ResponseEntity.ok(BasicResponse.success(response));
+    }
+
+    @Operation(summary = "닉네임 변경", description = "유저의 닉네임을 변경합니다.")
+    @PatchMapping("/mypage/nickname")
+    public ResponseEntity<BasicResponse<Void>> changeNickname(
+            @RequestBody @Valid ChangeNicknameRequest request
+    ) {
+        Authentication authentication = AuthenticationMemberUtils.getAuthentication();
+        memberService.changeNickname(request.getNickname(), authentication);
+        return ResponseEntity.ok(BasicResponse.success());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/request/member/ChangeNicknameRequest.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/request/member/ChangeNicknameRequest.java
@@ -1,0 +1,14 @@
+package com.dreamypatisiel.devdevdev.web.dto.request.member;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangeNicknameRequest {
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/request/member/ChangeNicknameRequest.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/request/member/ChangeNicknameRequest.java
@@ -1,6 +1,7 @@
 package com.dreamypatisiel.devdevdev.web.dto.request.member;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,4 +12,9 @@ import lombok.Setter;
 public class ChangeNicknameRequest {
     @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
+
+    @Builder
+    public ChangeNicknameRequest(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
@@ -1,0 +1,33 @@
+package com.dreamypatisiel.devdevdev.domain.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            ", true",           // 변경 이력 없음(null)
+            "0, false",         // 24시간 이내
+            "1, false",        // 24시간 이내
+            "24, true",        // 24시간 경과(경계)
+            "25, true",        // 24시간 초과
+    })
+    @DisplayName("닉네임 변경 가능 여부 파라미터 테스트")
+    void isAvailableToChangeNickname_Parameterized(Long hoursAgo, boolean expected) {
+        // given
+        Member member = new Member();
+        if (hoursAgo != null) {
+            member.changeNickname("닉네임", LocalDateTime.now().minusHours(hoursAgo));
+        }
+        // when
+        boolean result = member.isAvailableToChangeNickname();
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
@@ -1177,6 +1177,28 @@ class MemberServiceTest extends ElasticsearchSupportTest {
                 .hasMessage(INVALID_MEMBER_NOT_FOUND_MESSAGE);
     }
 
+    @Test
+    @DisplayName("회원은 닉네임을 변경할 수 있다.")
+    void changeNickname() {
+        // given
+        String oldNickname = "이전 닉네임";
+        String newNickname = "변경된 닉네임";
+        SocialMemberDto socialMemberDto = createSocialDto(userId, name, oldNickname, password, email, socialType, role);
+        Member member = Member.createMemberBy(socialMemberDto);
+        memberRepository.save(member);
+        UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
+                userPrincipal.getSocialType().name()));
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // when
+        memberService.changeNickname(newNickname, authentication);
+
+        // then
+        assertThat(member.getNickname().getNickname()).isEqualTo(newNickname);
+    }
+
     private static Company createCompany(String companyName, String officialUrl, String careerUrl,
                                          String imageUrl, String description, String industry) {
         return Company.builder()

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
@@ -1186,9 +1186,11 @@ class MemberServiceTest extends ElasticsearchSupportTest {
         // given
         String oldNickname = "이전 닉네임";
         String newNickname = "변경된 닉네임";
+
         SocialMemberDto socialMemberDto = createSocialDto(userId, name, oldNickname, password, email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
         memberRepository.save(member);
+
         UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),
@@ -1215,10 +1217,13 @@ class MemberServiceTest extends ElasticsearchSupportTest {
         // given
         String oldNickname = "이전 닉네임";
         String newNickname = "새 닉네임";
+
         SocialMemberDto socialMemberDto = createSocialDto(userId, name, oldNickname, password, email, socialType, role);
         Member member = Member.createMemberBy(socialMemberDto);
+
         member.changeNickname(oldNickname, LocalDateTime.now().minusHours(hoursAgo));
         memberRepository.save(member);
+
         UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(new OAuth2AuthenticationToken(userPrincipal, userPrincipal.getAuthorities(),

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/member/MyPageControllerUsedMockServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/member/MyPageControllerUsedMockServiceTest.java
@@ -3,9 +3,9 @@ package com.dreamypatisiel.devdevdev.web.controller.member;
 import static com.dreamypatisiel.devdevdev.web.dto.response.ResultType.SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,6 +21,7 @@ import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.web.controller.SupportControllerTest;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
+import com.dreamypatisiel.devdevdev.web.dto.request.member.ChangeNicknameRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.ResultType;
 import com.dreamypatisiel.devdevdev.web.dto.response.comment.MyWrittenCommentResponse;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +29,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.dreamypatisiel.devdevdev.web.dto.response.subscription.SubscribedCompanyResponse;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +49,8 @@ public class MyPageControllerUsedMockServiceTest extends SupportControllerTest {
     MemberService memberService;
     @MockBean
     MemberNicknameDictionaryService memberNicknameDictionaryService;
+    @Autowired
+    EntityManager em;
 
     @Test
     @DisplayName("회원은 랜덤 닉네임을 생성할 수 있다.")
@@ -67,6 +71,32 @@ public class MyPageControllerUsedMockServiceTest extends SupportControllerTest {
                 .andExpect(jsonPath("$.resultType").value(SUCCESS.name()))
                 .andExpect(jsonPath("$.data").isNotEmpty())
                 .andExpect(jsonPath("$.data").isString());
+    }
+
+    @Test
+    @DisplayName("회원은 닉네임을 변경할 수 있다.")
+    void changeNickname() throws Exception {
+        // given
+        String newNickname = "변경된 닉네임";
+        ChangeNicknameRequest request = createChangeNicknameRequest(newNickname);
+        request.setNickname(newNickname);
+
+        // when
+        doNothing().when(memberService).changeNickname(any(), any());
+
+        // then
+        mockMvc.perform(patch("/devdevdev/api/v1/mypage/nickname")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(request))
+                                .characterEncoding(StandardCharsets.UTF_8)
+                                .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultType").value(SUCCESS.name()));
+
+        // 서비스 메서드가 호출되었는지 검증
+        verify(memberService).changeNickname(eq(newNickname), any());
     }
 
     @Test
@@ -300,6 +330,12 @@ public class MyPageControllerUsedMockServiceTest extends SupportControllerTest {
                 .email(email)
                 .socialType(SocialType.valueOf(socialType))
                 .role(Role.valueOf(role))
+                .build();
+    }
+
+    private ChangeNicknameRequest createChangeNicknameRequest(String nickname) {
+        return ChangeNicknameRequest.builder()
+                .nickname(nickname)
                 .build();
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsUsedMockServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsUsedMockServiceTest.java
@@ -8,18 +8,17 @@ import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerato
 import static com.dreamypatisiel.devdevdev.web.docs.format.ApiDocsFormatGenerator.uniqueCommentIdType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -35,6 +34,7 @@ import com.dreamypatisiel.devdevdev.domain.service.member.MemberService;
 import com.dreamypatisiel.devdevdev.global.constant.SecurityConstant;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.SocialMemberDto;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
+import com.dreamypatisiel.devdevdev.web.dto.request.member.ChangeNicknameRequest;
 import com.dreamypatisiel.devdevdev.web.dto.response.comment.MyWrittenCommentResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -90,6 +90,38 @@ public class MyPageControllerDocsUsedMockServiceTest extends SupportControllerDo
                         fieldWithPath("data").type(JsonFieldType.STRING).description("응답 데이터(생성된 랜덤 닉네임)")
                 )
         ));
+    }
+
+    @Test
+    @DisplayName("회원은 닉네임을 변경할 수 있다.")
+    void changeNickname() throws Exception {
+        // given
+        String newNickname = "변경된 닉네임";
+        ChangeNicknameRequest request = createChangeNicknameRequest(newNickname);
+
+        // when
+        doNothing().when(memberService).changeNickname(any(), any());
+
+        // then
+        mockMvc.perform(patch("/devdevdev/api/v1/mypage/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(request))
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .header(SecurityConstant.AUTHORIZATION_HEADER, SecurityConstant.BEARER_PREFIX + accessToken))
+                .andExpect(status().isOk())
+                .andDo(document("change-nickname",
+                        requestFields(
+                                fieldWithPath("nickname").description("변경할 닉네임")
+                        ),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER).description("Bearer 엑세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("resultType").description("성공 여부")
+                        )
+                ));
+
+        verify(memberService).changeNickname(eq(newNickname), any());
     }
 
     @Test
@@ -421,6 +453,12 @@ public class MyPageControllerDocsUsedMockServiceTest extends SupportControllerDo
                 .email(email)
                 .socialType(SocialType.valueOf(socialType))
                 .role(Role.valueOf(role))
+                .build();
+    }
+
+    private ChangeNicknameRequest createChangeNicknameRequest(String nickname) {
+        return ChangeNicknameRequest.builder()
+                .nickname(nickname)
                 .build();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 회원은 닉네임을 변경할 수 있다.
- 익명 회원은 닉네임 변경을 할 수 없다. (401)

## 🔗 참고할만한 자료(선택)
X

## 💬 리뷰 요구사항(선택)
- 자유 닉네임 설정 가능성을 고려해 "A B C" 형식 유효성 검사는 생략했는데, 지금 단계에서는 넣는 게 좋을까요?