### PR TITLE
[DP-537] fix(login): 로그인 시 신규 회원 여부 쿠키에 추가

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/model/JwtCookieConstant.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/jwt/model/JwtCookieConstant.java
@@ -7,4 +7,5 @@ public class JwtCookieConstant {
     public static final String DEVDEVDEV_MEMBER_NICKNAME = "DEVDEVDEV_MEMBER_NICKNAME";
     public static final String DEVDEVDEV_MEMBER_EMAIL = "DEVDEVDEV_MEMBER_EMAIL";
     public static final String DEVDEVDEV_MEMBER_IS_ADMIN = "DEVDEVDEV_MEMBER_IS_ADMIN";
+    public static final String DEVDEVDEV_MEMBER_IS_NEW = "DEVDEVDEV_MEMBER_IS_NEW";
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -3,15 +3,19 @@ package com.dreamypatisiel.devdevdev.global.security.oauth2.handler;
 import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.enums.SocialType;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
+import com.dreamypatisiel.devdevdev.global.security.jwt.model.JwtCookieConstant;
 import com.dreamypatisiel.devdevdev.global.security.jwt.model.Token;
 import com.dreamypatisiel.devdevdev.global.security.jwt.service.JwtMemberService;
 import com.dreamypatisiel.devdevdev.global.security.jwt.service.TokenService;
 import com.dreamypatisiel.devdevdev.global.security.oauth2.model.OAuth2UserProvider;
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import com.dreamypatisiel.devdevdev.global.utils.CookieUtils;
 import com.dreamypatisiel.devdevdev.global.utils.UriUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collection;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,8 +57,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         CookieUtils.configJwtCookie(response, token);
 
         // 유저 정보 쿠키에 저장
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
         Member member = memberProvider.getMemberByAuthentication(authentication);
-        CookieUtils.configMemberCookie(response, member);
+        CookieUtils.configMemberCookie(response, member, userPrincipal.isNewMember());
 
         // 리다이렉트 설정
         String redirectUri = UriUtils.createUriByDomainAndEndpoint(domain, endpoint);

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/UserPrincipal.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/UserPrincipal.java
@@ -34,6 +34,8 @@ public class UserPrincipal implements OAuth2User, UserDetails {
     private final Collection<? extends GrantedAuthority> authorities;
     @Setter(value = AccessLevel.PRIVATE)
     private Map<String, Object> attributes = new HashMap<>();
+    @Getter
+    private boolean isNewMember;
 
     public static UserPrincipal createByMember(Member member) {
         List<SimpleGrantedAuthority> simpleGrantedAuthorities = Collections.singletonList(
@@ -51,9 +53,10 @@ public class UserPrincipal implements OAuth2User, UserDetails {
         );
     }
 
-    public static UserPrincipal createByMemberAndAttributes(Member member, Map<String, Object> attributes) {
+    public static UserPrincipal createByMemberAndAttributes(Member member, Map<String, Object> attributes, boolean isNewMember) {
         UserPrincipal userPrincipal = UserPrincipal.createByMember(member);
         userPrincipal.setAttributes(attributes);
+        userPrincipal.isNewMember = isNewMember;
         return userPrincipal;
     }
 

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/OAuth2MemberService.java
@@ -27,7 +27,7 @@ public class OAuth2MemberService {
     public UserPrincipal register(OAuth2UserProvider oAuth2UserProvider, OAuth2User oAuth2User) {
         Optional<Member> optionalMember = findMemberByOAuth2UserProvider(oAuth2UserProvider);
         if (optionalMember.isPresent()) {
-            return UserPrincipal.createByMemberAndAttributes(optionalMember.get(), oAuth2User.getAttributes());
+            return UserPrincipal.createByMemberAndAttributes(optionalMember.get(), oAuth2User.getAttributes(), false);
         }
 
         // 데이터베이스 회원이 없으면 회원가입 시킨다.
@@ -40,7 +40,7 @@ public class OAuth2MemberService {
 
         Member newMember = memberRepository.save(Member.createMemberBy(socialMemberDto));
 
-        return UserPrincipal.createByMemberAndAttributes(newMember, oAuth2User.getAttributes());
+        return UserPrincipal.createByMemberAndAttributes(newMember, oAuth2User.getAttributes(), true);
     }
 
     private Optional<Member> findMemberByOAuth2UserProvider(OAuth2UserProvider oAuth2UserProvider) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtils.java
@@ -99,7 +99,7 @@ public abstract class CookieUtils {
                 ACTIVE, DEFAULT_MAX_AGE, false, true);
     }
 
-    public static void configMemberCookie(HttpServletResponse response, Member member) {
+    public static void configMemberCookie(HttpServletResponse response, Member member, boolean isNewMember) {
         // 닉네임 UTF-8 인코딩 필요
         String nickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
 
@@ -109,6 +109,8 @@ public abstract class CookieUtils {
                 member.getEmailAsString(), DEFAULT_MAX_AGE, false, true);
         addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_IS_ADMIN,
                 String.valueOf(member.isAdmin()), DEFAULT_MAX_AGE, false, true);
+        addCookieToResponse(response, JwtCookieConstant.DEVDEVDEV_MEMBER_IS_NEW,
+                String.valueOf(isNewMember), DEFAULT_MAX_AGE, false, true);
     }
 
     private static void validationCookieEmpty(Cookie[] cookies) {

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/handler/OAuth2SuccessHandlerTest.java
@@ -56,7 +56,7 @@ class OAuth2SuccessHandlerTest {
         Map<String, Object> kakaoAttributes = new HashMap<>();
         kakaoAttributes.put(KakaoMember.EMAIL, email);
         attributes.put(KakaoMember.KAKAO_ACCOUNT, kakaoAttributes);
-        UserPrincipal userPrincipal = UserPrincipal.createByMemberAndAttributes(member, attributes);
+        UserPrincipal userPrincipal = UserPrincipal.createByMemberAndAttributes(member, attributes, false);
 
         // OAuth2AuthenticationToken 생성
         SecurityContext context = SecurityContextHolder.getContext();
@@ -82,6 +82,7 @@ class OAuth2SuccessHandlerTest {
     @DisplayName("OAuth2.0 로그인 성공 시"
             + " 토큰을 생성하고 토큰을 쿠키에 저장하고"
             + " 로그인된 회원의 이메일과 닉네임을 쿠키에 저장하고"
+            + " 로그인된 회원의 신규회원 여부를 쿠키에 저장하고"
             + " 리다이렉트를 설정하고"
             + " 회원에 리프레시 토큰을 저장한다.")
     void onAuthenticationSuccess() throws IOException {
@@ -105,6 +106,7 @@ class OAuth2SuccessHandlerTest {
         Cookie nicknameCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME);
         Cookie emailCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL);
         Cookie isAdmin = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_IS_ADMIN);
+        Cookie isNewMember = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_IS_NEW);
 
         assertAll(
                 () -> assertThat(accessCookie).isNotNull(),
@@ -112,7 +114,8 @@ class OAuth2SuccessHandlerTest {
                 () -> assertThat(loginStatusCookie).isNotNull(),
                 () -> assertThat(nicknameCookie).isNotNull(),
                 () -> assertThat(emailCookie).isNotNull(),
-                () -> assertThat(isAdmin).isNotNull()
+                () -> assertThat(isAdmin).isNotNull(),
+                () -> assertThat(isNewMember).isNotNull()
         );
         assertAll(
                 () -> assertThat(accessCookie.isHttpOnly()).isFalse(),

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/UserPrincipalTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/model/UserPrincipalTest.java
@@ -52,7 +52,7 @@ class UserPrincipalTest {
         Map<String, Object> attributes = new HashMap<>();
 
         // when
-        UserPrincipal userPrincipal = UserPrincipal.createByMemberAndAttributes(member, attributes);
+        UserPrincipal userPrincipal = UserPrincipal.createByMemberAndAttributes(member, attributes, false);
 
         // then
         assertAll(

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/security/oauth2/service/AppOAuth2MemberServiceTest.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.dreamypatisiel.devdevdev.global.security.oauth2.model.UserPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,11 +72,12 @@ class AppOAuth2MemberServiceTest {
         memberNicknameDictionaryRepository.saveAll(nicknameDictionaryWords);
 
         // when
-        oAuth2MemberService.register(mockOAuth2UserProvider, mockOAuth2User);
+        UserPrincipal userPrincipal = oAuth2MemberService.register(mockOAuth2UserProvider, mockOAuth2User);
 
         // then
         Member member = memberRepository.findMemberByUserIdAndSocialType(userId, socialType).get();
         assertThat(member).isNotNull();
+        assertThat(userPrincipal.isNewMember()).isEqualTo(true);
     }
 
     @Test

--- a/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/global/utils/CookieUtilsTest.java
@@ -267,19 +267,22 @@ class CookieUtilsTest {
         Member member = Member.createMemberBy(socialMemberDto);
         String encodedNickname = URLEncoder.encode(member.getNicknameAsString(), StandardCharsets.UTF_8);
         String email = member.getEmailAsString();
+        boolean isNewMember = true;
 
         // when
-        CookieUtils.configMemberCookie(response, member);
+        CookieUtils.configMemberCookie(response, member, isNewMember);
 
         // then
         Cookie nicknameCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_NICKNAME);
         Cookie emailCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_EMAIL);
         Cookie isAdmin = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_IS_ADMIN);
+        Cookie isNewMemberCookie = response.getCookie(JwtCookieConstant.DEVDEVDEV_MEMBER_IS_NEW);
 
         assertAll(
                 () -> assertThat(nicknameCookie).isNotNull(),
                 () -> assertThat(emailCookie).isNotNull(),
-                () -> assertThat(isAdmin).isNotNull()
+                () -> assertThat(isAdmin).isNotNull(),
+                () -> assertThat(isNewMemberCookie).isNotNull()
         );
 
         assertAll(
@@ -304,6 +307,14 @@ class CookieUtilsTest {
                 () -> assertThat(isAdmin.getMaxAge()).isEqualTo(CookieUtils.DEFAULT_MAX_AGE),
                 () -> assertThat(isAdmin.getSecure()).isTrue(),
                 () -> assertThat(isAdmin.isHttpOnly()).isFalse()
+        );
+
+        assertAll(
+                () -> assertThat(isNewMemberCookie.getName()).isEqualTo(JwtCookieConstant.DEVDEVDEV_MEMBER_IS_NEW),
+                () -> assertThat(isNewMemberCookie.getValue()).isEqualTo(String.valueOf(isNewMember)),
+                () -> assertThat(isNewMemberCookie.getMaxAge()).isEqualTo(CookieUtils.DEFAULT_MAX_AGE),
+                () -> assertThat(isNewMemberCookie.getSecure()).isTrue(),
+                () -> assertThat(isNewMemberCookie.isHttpOnly()).isFalse()
         );
     }
 


### PR DESCRIPTION
## 📝 작업 내용
- 신규 회원 가입시 웰컴 팝업을 띄우기 위하여, 신규 회원 여부(boolean)를 쿠키에 추가하였습니다.
  - 해당 쿠키는 로그인 성공시 유저 정보(닉네임, 이메일, 관리자여부)와 함께 쿠키에 담겨 클라이언트로 리다이렉트됩니다.
  - `DEVDEVDEV_MEMBER_IS_NEW` : true / false
![스크린샷 2025-07-09 오후 11 36 14](https://github.com/user-attachments/assets/81c406ef-c1aa-41a3-9e87-af4bd6d6d146)

## 🔗 참고할만한 자료(선택)


## 💬 리뷰 요구사항(선택)
### UserPrincipal 에 isNewMember 필드를 추가한 이유
- 신규 회원 여부를 확인하여 회원가입을 진행하는 부분(`OAuth2MemberService.register()`)과 로그인 성공 후 쿠키를 생성하여 응답에 담는 부분(`OAuth2SuccessHandler.onAuthenticationSuccess()`)이 분리되어 있어, 신규회원 여부를 어떻게 핸들러 쪽으로 전달할지 고민했는데요!
  - 1)UserPrincipal 에 isNewMember 필드를 추가하여 전달
  - 2)MDC(스레드 로컬)에 저장한 후 꺼내서 사용
- 이중 신규 회원 여부는 로그인 성공 후 핸들러에서 쿠키 및 응답을 생성할 때 꼭 필요한 정보이기 때문에 인증 객체인 UserPrincipal에 포함하는 것이 더욱 적합하다고 판단했습니다.
- MDC는 tracd_id, ip 등 부가적인 요청 정보를 저장하는 용도가 적합하다고 알고있기도 하고, 신규 회원 관련 로직이 퍼지지 않고 UserPrincipal 한 곳에 모여있도록 하는 것이 더 명확하다고 생각해서 UserPrincipal에 추가하는 방식으로 구현했습니다~!!