### PR TITLE
[DP-535] 닉네임 변경 API 응답 변경(변경된 닉네임 문자열 추가)

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -295,7 +295,7 @@ public class MemberService {
      * @Since: 2025.07.03
      */
     @Transactional
-    public void changeNickname(String nickname, Authentication authentication) {
+    public String changeNickname(String nickname, Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         if (!member.canChangeNickname()) {
@@ -303,6 +303,7 @@ public class MemberService {
         }
 
         member.changeNickname(nickname, timeProvider.getLocalDateTimeNow());
+        return member.getNicknameAsString();
     }
 
     /**

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/member/MypageController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/member/MypageController.java
@@ -147,12 +147,12 @@ public class MypageController {
 
     @Operation(summary = "닉네임 변경", description = "유저의 닉네임을 변경합니다.")
     @PatchMapping("/mypage/nickname")
-    public ResponseEntity<BasicResponse<Void>> changeNickname(
+    public ResponseEntity<BasicResponse<String>> changeNickname(
             @RequestBody @Valid ChangeNicknameRequest request
     ) {
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();
-        memberService.changeNickname(request.getNickname(), authentication);
-        return ResponseEntity.ok(BasicResponse.success());
+        String response = memberService.changeNickname(request.getNickname(), authentication);
+        return ResponseEntity.ok(BasicResponse.success(response));
     }
 
     @Operation(summary = "닉네임 변경 가능 여부 조회", description = "닉네임 변경 가능 여부를 true/false로 반환합니다.")

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberServiceTest.java
@@ -1198,10 +1198,11 @@ class MemberServiceTest extends ElasticsearchSupportTest {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // when
-        memberService.changeNickname(newNickname, authentication);
+        String changedNickname = memberService.changeNickname(newNickname, authentication);
 
         // then
         assertThat(member.getNickname().getNickname()).isEqualTo(newNickname);
+        assertThat(changedNickname).isEqualTo(newNickname);
     }
 
     @DisplayName("회원이 24시간 이내에 닉네임을 변경한 적이 있다면 예외가 발생한다.")

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/member/MyPageControllerUsedMockServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/member/MyPageControllerUsedMockServiceTest.java
@@ -85,7 +85,7 @@ public class MyPageControllerUsedMockServiceTest extends SupportControllerTest {
         request.setNickname(newNickname);
 
         // when
-        doNothing().when(memberService).changeNickname(any(), any());
+        when(memberService.changeNickname(any(), any())).thenReturn(newNickname);
 
         // then
         mockMvc.perform(patch("/devdevdev/api/v1/mypage/nickname")
@@ -96,7 +96,8 @@ public class MyPageControllerUsedMockServiceTest extends SupportControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultType").value(SUCCESS.name()));
+                .andExpect(jsonPath("$.resultType").value(SUCCESS.name()))
+                .andExpect(jsonPath("$.data").value(newNickname));
 
         // 서비스 메서드가 호출되었는지 검증
         verify(memberService).changeNickname(eq(newNickname), any());

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsUsedMockServiceTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/MyPageControllerDocsUsedMockServiceTest.java
@@ -106,7 +106,7 @@ public class MyPageControllerDocsUsedMockServiceTest extends SupportControllerDo
         ChangeNicknameRequest request = createChangeNicknameRequest(newNickname);
 
         // when
-        doNothing().when(memberService).changeNickname(any(), any());
+        when(memberService.changeNickname(any(), any())).thenReturn(newNickname);
 
         // then
         mockMvc.perform(patch("/devdevdev/api/v1/mypage/nickname")
@@ -123,7 +123,8 @@ public class MyPageControllerDocsUsedMockServiceTest extends SupportControllerDo
                                 headerWithName(AUTHORIZATION_HEADER).description("Bearer 엑세스 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("resultType").description("성공 여부")
+                                fieldWithPath("resultType").description("성공 여부"),
+                                fieldWithPath("data").description("변경된 닉네임")
                         )
                 ));
 


### PR DESCRIPTION
## 📝 작업 내용
- 닉네임 변경 API 응답값에 변경된 닉네임 문자열 추가
- https://dreamy-patisiel.slack.com/archives/C0673T3JFJM/p1752071043713299

## 🔗 참고할만한 자료(선택)


## 💬 리뷰 요구사항(선택)
