### PR TITLE
fix(nickname): 회원 닉네임 변경 가능 시간 환경변수화

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -196,8 +196,8 @@ public class Member extends BasicTime {
         this.nicknameUpdatedAt = now;
     }
 
-    public boolean canChangeNickname(int restrictionHours, LocalDateTime now) {
+    public boolean canChangeNickname(int restrictionMinutes, LocalDateTime now) {
         return nicknameUpdatedAt == null
-                || ChronoUnit.HOURS.between(nicknameUpdatedAt, now) >= restrictionHours;
+                || ChronoUnit.MINUTES.between(nicknameUpdatedAt, now) >= restrictionMinutes;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -196,7 +196,7 @@ public class Member extends BasicTime {
         this.nicknameUpdatedAt = now;
     }
 
-    public boolean canChangeNickname(long restrictionHours) {
+    public boolean canChangeNickname(int restrictionHours) {
         return nicknameUpdatedAt == null
                 || ChronoUnit.HOURS.between(nicknameUpdatedAt, LocalDateTime.now()) >= restrictionHours;
     }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -196,8 +196,8 @@ public class Member extends BasicTime {
         this.nicknameUpdatedAt = now;
     }
 
-    public boolean canChangeNickname() {
+    public boolean canChangeNickname(long restrictionHours) {
         return nicknameUpdatedAt == null
-                || ChronoUnit.HOURS.between(nicknameUpdatedAt, LocalDateTime.now()) >= 24;
+                || ChronoUnit.HOURS.between(nicknameUpdatedAt, LocalDateTime.now()) >= restrictionHours;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/entity/Member.java
@@ -196,8 +196,8 @@ public class Member extends BasicTime {
         this.nicknameUpdatedAt = now;
     }
 
-    public boolean canChangeNickname(int restrictionHours) {
+    public boolean canChangeNickname(int restrictionHours, LocalDateTime now) {
         return nicknameUpdatedAt == null
-                || ChronoUnit.HOURS.between(nicknameUpdatedAt, LocalDateTime.now()) >= restrictionHours;
+                || ChronoUnit.HOURS.between(nicknameUpdatedAt, now) >= restrictionHours;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/policy/NicknameChangePolicy.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/policy/NicknameChangePolicy.java
@@ -1,0 +1,14 @@
+package com.dreamypatisiel.devdevdev.domain.policy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NicknameChangePolicy {
+    @Value("${nickname.change.interval.hours:24}")
+    private int nicknameChangeIntervalHours;
+
+    public int getNicknameChangeIntervalHours() {
+        return nicknameChangeIntervalHours;
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/policy/NicknameChangePolicy.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/policy/NicknameChangePolicy.java
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class NicknameChangePolicy {
-    @Value("${nickname.change.interval.hours:24}")
-    private int nicknameChangeIntervalHours;
+    @Value("${nickname.change.interval.minutes:1440}")
+    private int nicknameChangeIntervalMinutes;
 
-    public int getNicknameChangeIntervalHours() {
-        return nicknameChangeIntervalHours;
+    public int getNicknameChangeIntervalMinutes() {
+        return nicknameChangeIntervalMinutes;
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -302,7 +302,7 @@ public class MemberService {
     public String changeNickname(String nickname, Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
-        if (!member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours(), timeProvider.getLocalDateTimeNow())) {
+        if (!member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalMinutes(), timeProvider.getLocalDateTimeNow())) {
             throw new NicknameException(NICKNAME_CHANGE_RATE_LIMIT_MESSAGE);
         }
 
@@ -317,6 +317,6 @@ public class MemberService {
      */
     public boolean canChangeNickname(Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
-        return member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours(), timeProvider.getLocalDateTimeNow());
+        return member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalMinutes(), timeProvider.getLocalDateTimeNow());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -302,7 +302,7 @@ public class MemberService {
     public String changeNickname(String nickname, Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
-        if (!member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours())) {
+        if (!member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours(), timeProvider.getLocalDateTimeNow())) {
             throw new NicknameException(NICKNAME_CHANGE_RATE_LIMIT_MESSAGE);
         }
 
@@ -317,6 +317,6 @@ public class MemberService {
      */
     public boolean canChangeNickname(Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
-        return member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours());
+        return member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours(), timeProvider.getLocalDateTimeNow());
     }
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/member/MemberService.java
@@ -2,6 +2,7 @@ package com.dreamypatisiel.devdevdev.domain.service.member;
 
 import com.dreamypatisiel.devdevdev.domain.entity.*;
 import com.dreamypatisiel.devdevdev.domain.entity.embedded.CustomSurveyAnswer;
+import com.dreamypatisiel.devdevdev.domain.policy.NicknameChangePolicy;
 import com.dreamypatisiel.devdevdev.domain.repository.CompanyRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.comment.CommentRepository;
 import com.dreamypatisiel.devdevdev.domain.repository.comment.MyWrittenCommentDto;
@@ -47,6 +48,8 @@ import java.util.stream.Stream;
 import static com.dreamypatisiel.devdevdev.domain.exception.MemberExceptionMessage.MEMBER_INCOMPLETE_SURVEY_MESSAGE;
 import static com.dreamypatisiel.devdevdev.domain.exception.NicknameExceptionMessage.NICKNAME_CHANGE_RATE_LIMIT_MESSAGE;
 
+import org.springframework.beans.factory.annotation.Value;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -63,6 +66,7 @@ public class MemberService {
     private final SurveyAnswerJdbcTemplateRepository surveyAnswerJdbcTemplateRepository;
     private final CommentRepository commentRepository;
     private final CompanyRepository companyRepository;
+    private final NicknameChangePolicy nicknameChangePolicy;
 
     /**
      * 회원 탈퇴 회원의 북마크와 회원 정보를 삭제합니다.
@@ -290,7 +294,7 @@ public class MemberService {
     }
 
     /**
-     * @Note: 유저의 닉네임을 변경합니다. 최근 24시간 이내에 변경한 이력이 있다면 닉네임 변경이 불가능합니다.
+     * @Note: 유저의 닉네임을 변경합니다. 설정된 제한 시간 이내에 변경한 이력이 있다면 닉네임 변경이 불가능합니다.
      * @Author: 유소영
      * @Since: 2025.07.03
      */
@@ -298,7 +302,7 @@ public class MemberService {
     public String changeNickname(String nickname, Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
-        if (!member.canChangeNickname()) {
+        if (!member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours())) {
             throw new NicknameException(NICKNAME_CHANGE_RATE_LIMIT_MESSAGE);
         }
 
@@ -313,6 +317,6 @@ public class MemberService {
      */
     public boolean canChangeNickname(Authentication authentication) {
         Member member = memberProvider.getMemberByAuthentication(authentication);
-        return member.canChangeNickname();
+        return member.canChangeNickname(nicknameChangePolicy.getNicknameChangeIntervalHours());
     }
 }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
@@ -12,22 +12,45 @@ class MemberTest {
     @ParameterizedTest
     @CsvSource({
             ", true",           // 변경 이력 없음(null)
-            "0, false",         // 24시간 이내
-            "1, false",        // 24시간 이내
-            "24, true",        // 24시간 경과(경계)
-            "25, true",        // 24시간 초과
+            "60, false",         // 24시간 이내
+            "1439, false",        // 24시간 이내
+            "1440, true",        // 24시간 경과(경계)
+            "1550, true",        // 24시간 초과
     })
     @DisplayName("닉네임 변경 가능 여부 파라미터 테스트")
-    void canChangeNickname(Long hoursAgo, boolean expected) {
+    void canChangeNickname(Long minutesAgo, boolean expected) {
         // given
         LocalDateTime now = LocalDateTime.now();
         Member member = new Member();
-        if (hoursAgo != null) {
-            member.changeNickname("닉네임", now.minusHours(hoursAgo));
+        if (minutesAgo != null) {
+            member.changeNickname("닉네임", now.minusMinutes(minutesAgo));
         }
-        int nicknameChangeIntervalHours = 24;
+        int restrictionMinutes = 1440; // 24시간
         // when
-        boolean result = member.canChangeNickname(nicknameChangeIntervalHours, now);
+        boolean result = member.canChangeNickname(restrictionMinutes, now);
+        // then
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ", true",           // 변경 이력 없음(null)
+            "0, false",         // 24시간 이내
+            "1, true",        // 24시간 이내
+            "60, true",        // 24시간 경과(경계)
+            "1440, true",        // 24시간 초과
+    })
+    @DisplayName("닉네임 변경 가능 여부 파라미터 테스트")
+    void canChangeNicknameWhenDev(Long minutesAgo, boolean expected) {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Member member = new Member();
+        if (minutesAgo != null) {
+            member.changeNickname("닉네임", now.minusMinutes(minutesAgo));
+        }
+        int restrictionMinutes = 1; // 1분
+        // when
+        boolean result = member.canChangeNickname(restrictionMinutes, now);
         // then
         assertThat(result).isEqualTo(expected);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
@@ -24,8 +24,9 @@ class MemberTest {
         if (hoursAgo != null) {
             member.changeNickname("닉네임", LocalDateTime.now().minusHours(hoursAgo));
         }
+        int nicknameChangeIntervalHours = 24;
         // when
-        boolean result = member.canChangeNickname();
+        boolean result = member.canChangeNickname(nicknameChangeIntervalHours);
         // then
         assertThat(result).isEqualTo(expected);
     }

--- a/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/domain/entity/MemberTest.java
@@ -20,13 +20,14 @@ class MemberTest {
     @DisplayName("닉네임 변경 가능 여부 파라미터 테스트")
     void canChangeNickname(Long hoursAgo, boolean expected) {
         // given
+        LocalDateTime now = LocalDateTime.now();
         Member member = new Member();
         if (hoursAgo != null) {
-            member.changeNickname("닉네임", LocalDateTime.now().minusHours(hoursAgo));
+            member.changeNickname("닉네임", now.minusHours(hoursAgo));
         }
         int nicknameChangeIntervalHours = 24;
         // when
-        boolean result = member.canChangeNickname(nicknameChangeIntervalHours);
+        boolean result = member.canChangeNickname(nicknameChangeIntervalHours, now);
         // then
         assertThat(result).isEqualTo(expected);
     }


### PR DESCRIPTION
## 📝 작업 내용
- 사연: https://dreamy-patisiel.slack.com/archives/C066AN5CS4X/p1752991340960229
- 닉네임 변경 가능 시간 환경변수화(없으면 기본값 24시간, dev 환경변수만 추가하면 됨)
```yml
# application-dev.yml

# 닉네임 변경 제한 설정 (dev 환경에서는 0시간으로 설정하여 제한 없음)
nickname:
  change:
    interval:
      hours: 0

```

- [ ] application-dev.yml 변경 업데이트

## 🔗 참고할만한 자료(선택)

## 💬 리뷰 요구사항(선택)
환경변수화, 코드로 분기, DB로 관리하는 것 중 환경변수로 둔 이유는 다음과 같습니다!
1. 코드로 분기 - 개발환경을 위한 정책 분기가 코드로 관리되는 것이 적절하지 않다고 판단
2. DB로 관리 - 다소 오버엔지니어링, 개발환경에 다른 정책분리 수요가 많아지면 고려해볼만함, 계속해서 DB를 조회해야하거나, 인메모리로 올려서 캐싱하더라도 캐시를 날리고 새로 업데이트하는 기능을 달지 않으면 장점이 없어보임
3. 환경변수화 - 가장 간편하게 분리 및 수정 배포 가능