### PR TITLE
[DP-516] 기술블로그 검색어 조회시 score 누락 이슈 수정

### DIFF
--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechArticleDto.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/TechArticleDto.java
@@ -1,0 +1,16 @@
+package com.dreamypatisiel.devdevdev.domain.repository.techArticle;
+
+import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TechArticleDto {
+    private final TechArticle techArticle;
+    private final Double score;
+    
+    public static TechArticleDto of(TechArticle techArticle, Double score) {
+        return new TechArticleDto(techArticle, score);
+    }
+}

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryCustom.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryCustom.java
@@ -6,6 +6,7 @@ import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
 
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
+import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -13,6 +14,6 @@ public interface TechArticleRepositoryCustom {
     Slice<TechArticle> findBookmarkedByMemberAndCursor(Pageable pageable, Long techArticleId, BookmarkSort bookmarkSort,
                                                        Member member);
 
-    SliceCustom<TechArticle> findTechArticlesByCursor(Pageable pageable, Long techArticleId, TechArticleSort techArticleSort,
-                                                      Long companyId, String keyword, Float score);
+    SliceCustom<TechArticleDto> findTechArticlesByCursor(Pageable pageable, Long techArticleId, TechArticleSort techArticleSort,
+                                                      Long companyId, String keyword, Double score);
 }

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
@@ -204,7 +204,7 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     // 키워드 검색을 위한 커서 조건 생성
     private Predicate getCursorConditionForKeywordSearch(TechArticleSort techArticleSort, Long techArticleId, 
                                                         Double score, NumberTemplate<Double> totalScore) {
-        if (ObjectUtils.isEmpty(techArticleId)) {
+        if (ObjectUtils.isEmpty(techArticleId) || ObjectUtils.isEmpty(score)) {
             return null;
         }
         

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
@@ -9,6 +9,8 @@ import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkSort;
 import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
+import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleDto;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -50,9 +52,9 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     }
 
     @Override
-    public SliceCustom<TechArticle> findTechArticlesByCursor(Pageable pageable, Long techArticleId,
+    public SliceCustom<TechArticleDto> findTechArticlesByCursor(Pageable pageable, Long techArticleId,
                                                              TechArticleSort techArticleSort, Long companyId,
-                                                             String keyword, Float score
+                                                             String keyword, Double score
     ) {
         // 키워드가 있는 경우 FULLTEXT 검색, 없는 경우 일반 조회
         if (StringUtils.hasText(keyword)) {
@@ -62,9 +64,9 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     }
 
     // 키워드 검색
-    private SliceCustom<TechArticle> findTechArticlesByCursorWithKeyword(Pageable pageable, Long techArticleId,
+    public SliceCustom<TechArticleDto> findTechArticlesByCursorWithKeyword(Pageable pageable, Long techArticleId,
                                                                          TechArticleSort techArticleSort, Long companyId,
-                                                                         String keyword, Float score
+                                                                         String keyword, Double score
     ) {
         // FULLTEXT 검색 조건 생성
         BooleanExpression titleMatch = Expressions.booleanTemplate(
@@ -92,13 +94,21 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
                 "({0} * 2.0) + {1}", titleScore, contentsScore
         );
         
-        List<TechArticle> contents = query.selectFrom(techArticle)
+        // TechArticle과 score를 함께 조회
+        List<Tuple> results = query.select(techArticle, totalScore)
+                .from(techArticle)
                 .where(titleMatch.or(contentsMatch))
                 .where(getCompanyIdCondition(companyId))
                 .where(getCursorConditionForKeywordSearch(techArticleSort, techArticleId, score, totalScore))
                 .orderBy(getOrderSpecifierForKeywordSearch(techArticleSort, totalScore), techArticle.id.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
+        
+        // Tuple을 TechArticleDto로 변환
+        List<TechArticleDto> contents = results.stream()
+                .map(result -> TechArticleDto.of(
+                        result.get(techArticle), result.get(totalScore)))
+                .toList();
         
         // 키워드 검색 결과 총 갯수
         long totalElements = query.select(techArticle.count())
@@ -111,15 +121,20 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     }
 
     // 일반 조회
-    private SliceCustom<TechArticle> findTechArticlesByCursorWithoutKeyword(Pageable pageable, Long techArticleId,
+    private SliceCustom<TechArticleDto> findTechArticlesByCursorWithoutKeyword(Pageable pageable, Long techArticleId,
                                                                             TechArticleSort techArticleSort, Long companyId
     ) {
-        List<TechArticle> contents = query.selectFrom(techArticle)
+        List<TechArticle> results = query.selectFrom(techArticle)
                 .where(getCursorConditionFromTechArticleSort(techArticleSort, techArticleId))
-                .where(companyId != null ? techArticle.company.id.eq(companyId) : null)
+                .where(getCompanyIdCondition(companyId))
                 .orderBy(techArticleSort(techArticleSort), techArticle.id.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
+
+        // Tuple을 TechArticleDto로 변환
+        List<TechArticleDto> contents = results.stream()
+                .map(result -> TechArticleDto.of(result, null))
+                .toList();
 
         // 기술블로그 총 갯수
         long totalElements = query.select(techArticle.count())
@@ -188,13 +203,13 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
 
     // 키워드 검색을 위한 커서 조건 생성
     private Predicate getCursorConditionForKeywordSearch(TechArticleSort techArticleSort, Long techArticleId, 
-                                                        Float score, NumberTemplate<Double> totalScore) {
-        if (ObjectUtils.isEmpty(techArticleId) || ObjectUtils.isEmpty(score)) {
+                                                        Double score, NumberTemplate<Double> totalScore) {
+        if (ObjectUtils.isEmpty(techArticleId)) {
             return null;
         }
         
         // HIGHEST_SCORE(정확도순)인 경우 스코어 기반 커서 사용
-        if (techArticleSort == TechArticleSort.HIGHEST_SCORE) {
+        if (techArticleSort == TechArticleSort.HIGHEST_SCORE || ObjectUtils.isEmpty(techArticleSort)) {
             return totalScore.lt(score.doubleValue())
                     .or(totalScore.eq(score.doubleValue())
                             .and(techArticle.id.lt(techArticleId)));
@@ -217,13 +232,13 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
     private OrderSpecifier<?> getOrderSpecifierForKeywordSearch(TechArticleSort techArticleSort, 
                                                                NumberTemplate<Double> totalScore) {
         // HIGHEST_SCORE(정확도순)인 경우 스코어 기반 정렬
-        if (techArticleSort == TechArticleSort.HIGHEST_SCORE) {
+        if (techArticleSort == TechArticleSort.HIGHEST_SCORE || ObjectUtils.isEmpty(techArticleSort)) {
             return totalScore.desc();
         }
         
         // 다른 정렬 방식인 경우 기존 정렬 사용
         return Optional.ofNullable(techArticleSort)
-                .orElse(TechArticleSort.HIGHEST_SCORE).getOrderSpecifierByTechArticleSort();
+                .orElse(TechArticleSort.LATEST).getOrderSpecifierByTechArticleSort();
     }
 
     public BooleanExpression getCompanyIdCondition(Long companyId) {

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/repository/techArticle/custom/TechArticleRepositoryImpl.java
@@ -89,9 +89,9 @@ public class TechArticleRepositoryImpl implements TechArticleRepositoryCustom {
                 techArticle.contents, keyword
         );
         
-        // 전체 스코어 계산 (제목 가중치 2배)
+        // 전체 스코어 계산 (제목 가중치 2배, 안전한 범위로 제한)
         NumberTemplate<Double> totalScore = Expressions.numberTemplate(Double.class,
-                "({0} * 2.0) + {1}", titleScore, contentsScore
+                "(LEAST({0}, 100000) * 2.0) + LEAST({1}, 100000)", titleScore, contentsScore
         );
         
         // TechArticle과 score를 함께 조회

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/GuestTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/GuestTechArticleService.java
@@ -11,6 +11,7 @@ import com.dreamypatisiel.devdevdev.domain.service.member.AnonymousMemberService
 import com.dreamypatisiel.devdevdev.global.utils.AuthenticationMemberUtils;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.*;
+import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -50,17 +51,19 @@ public class GuestTechArticleService extends TechArticleCommonService implements
     @Override
     public Slice<TechArticleMainResponse> getTechArticles(Pageable pageable, Long techArticleId,
                                                           TechArticleSort techArticleSort, String keyword,
-                                                          Long companyId, Float score, Authentication authentication) {
+                                                          Long companyId, Double score, Authentication authentication) {
         // 익명 사용자 호출인지 확인
         AuthenticationMemberUtils.validateAnonymousMethodCall(authentication);
 
         // 기술블로그 조회
-        SliceCustom<TechArticle> techArticles = techArticleRepository.findTechArticlesByCursor(
+        SliceCustom<TechArticleDto> techArticles = techArticleRepository.findTechArticlesByCursor(
                 pageable, techArticleId, techArticleSort, companyId, keyword, score);
 
         // 데이터 가공
         List<TechArticleMainResponse> techArticlesResponse = techArticles.stream()
-                .map(TechArticleMainResponse::of)
+                .map(techArticle -> TechArticleMainResponse.of(
+                        techArticle.getTechArticle(), techArticle.getScore()
+                ))
                 .toList();
 
         return new SliceCustom<>(techArticlesResponse, pageable, techArticles.hasNext(), techArticles.getTotalElements());

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/MemberTechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/MemberTechArticleService.java
@@ -5,10 +5,7 @@ import com.dreamypatisiel.devdevdev.domain.entity.Member;
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticle;
 import com.dreamypatisiel.devdevdev.domain.entity.TechArticleRecommend;
 import com.dreamypatisiel.devdevdev.domain.policy.TechArticlePopularScorePolicy;
-import com.dreamypatisiel.devdevdev.domain.repository.techArticle.BookmarkRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRecommendRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleRepository;
-import com.dreamypatisiel.devdevdev.domain.repository.techArticle.TechArticleSort;
+import com.dreamypatisiel.devdevdev.domain.repository.techArticle.*;
 import com.dreamypatisiel.devdevdev.global.common.MemberProvider;
 import com.dreamypatisiel.devdevdev.web.dto.SliceCustom;
 import com.dreamypatisiel.devdevdev.web.dto.response.techArticle.*;
@@ -50,17 +47,17 @@ public class MemberTechArticleService extends TechArticleCommonService implement
     @Override
     public Slice<TechArticleMainResponse> getTechArticles(Pageable pageable, Long techArticleId,
                                                           TechArticleSort techArticleSort, String keyword,
-                                                          Long companyId, Float score, Authentication authentication) {
+                                                          Long companyId, Double score, Authentication authentication) {
         // 회원 조회
         Member member = memberProvider.getMemberByAuthentication(authentication);
 
         // 기술블로그 조회
-        SliceCustom<TechArticle> techArticles = techArticleRepository.findTechArticlesByCursor(
+        SliceCustom<TechArticleDto> techArticles = techArticleRepository.findTechArticlesByCursor(
                 pageable, techArticleId, techArticleSort, companyId, keyword, score);
 
         // 데이터 가공
         List<TechArticleMainResponse> techArticlesResponse = techArticles.stream()
-                .map(techArticle -> TechArticleMainResponse.of(techArticle, member))
+                .map(techArticle -> TechArticleMainResponse.of(techArticle.getTechArticle(), member, techArticle.getScore()))
                 .toList();
 
         return new SliceCustom<>(techArticlesResponse, pageable, techArticles.hasNext(), techArticles.getTotalElements());

--- a/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/TechArticleService.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/domain/service/techArticle/techArticle/TechArticleService.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.Authentication;
 
 public interface TechArticleService {
     Slice<TechArticleMainResponse> getTechArticles(Pageable pageable, Long techArticleId, TechArticleSort techArticleSort,
-                                                   String keyword, Long companyId, Float score,
+                                                   String keyword, Long companyId, Double score,
                                                    Authentication authentication);
 
     TechArticleDetailResponse getTechArticle(Long techArticleId, String anonymousMemberId, Authentication authentication);

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleController.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleController.java
@@ -37,7 +37,7 @@ public class TechArticleController {
             @RequestParam(required = false) Long techArticleId,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long companyId,
-            @RequestParam(required = false) Float score
+            @RequestParam(required = false) Double score
     ) {
         TechArticleService techArticleService = techArticleServiceStrategy.getTechArticleService();
         Authentication authentication = AuthenticationMemberUtils.getAuthentication();

--- a/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponse.java
+++ b/src/main/java/com/dreamypatisiel/devdevdev/web/dto/response/techArticle/TechArticleMainResponse.java
@@ -31,13 +31,13 @@ public class TechArticleMainResponse {
     public final Long popularScore;
     public final Boolean isLogoImage;
     public final Boolean isBookmarked;
-    public final Float score;
+    public final Double score;
 
     @Builder
     private TechArticleMainResponse(Long id, String title, String contents, String author, CompanyResponse company,
                                     LocalDate regDate, String thumbnailUrl, String techArticleUrl,
                                     Long viewTotalCount, Long recommendTotalCount, Long commentTotalCount, Long popularScore,
-                                    Boolean isLogoImage, Boolean isBookmarked, Float score) {
+                                    Boolean isLogoImage, Boolean isBookmarked, Double score) {
         this.id = id;
         this.title = title;
         this.contents = contents;
@@ -96,7 +96,7 @@ public class TechArticleMainResponse {
                 .build();
     }
 
-    public static TechArticleMainResponse of(TechArticle techArticle, Member member, Float score) {
+    public static TechArticleMainResponse of(TechArticle techArticle, Member member, Double score) {
         CompanyResponse companyResponse = CompanyResponse.from(techArticle.getCompany());
         return TechArticleMainResponse.builder()
                 .id(techArticle.getId())
@@ -117,7 +117,7 @@ public class TechArticleMainResponse {
                 .build();
     }
 
-    public static TechArticleMainResponse of(TechArticle techArticle, Float score) {
+    public static TechArticleMainResponse of(TechArticle techArticle, Double score) {
         CompanyResponse companyResponse = CompanyResponse.from(techArticle.getCompany());
         return TechArticleMainResponse.builder()
                 .id(techArticle.getId())
@@ -146,8 +146,8 @@ public class TechArticleMainResponse {
         return thumbnailUrl.getUrl();
     }
 
-    private static Float getValidScore(Float score) {
-        return Objects.isNull(score) || Float.isNaN(score) ? null : score;
+    private static Double getValidScore(Double score) {
+        return Objects.isNull(score) || Double.isNaN(score) ? null : score;
     }
 
     private static String truncateString(String contents, int maxLength) {

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/notification/NotificationControllerTest.java
@@ -246,7 +246,7 @@ class NotificationControllerTest extends SupportControllerTest {
                                                                   String techArticleUrl, String title, String contents,
                                                                   Long companyId, String companyName, String careerUrl, String officialImageUrl,
                                                                   LocalDate regDate, String author, long recommendCount,
-                                                                  long commentCount, long viewCount, Boolean isBookmarked, Float score) {
+                                                                  long commentCount, long viewCount, Boolean isBookmarked, Double score) {
         return TechArticleMainResponse.builder()
                 .id(id)
                 .thumbnailUrl(thumbnailUrl)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/controller/techArticle/TechArticleControllerTest.java
@@ -55,7 +55,7 @@ class TechArticleControllerTest extends SupportControllerTest {
         TechArticleMainResponse response = createTechArticleMainResponse(
                 1L, "http://thumbnail.com", false, "http://article.com", "타이틀 1", "내용 1",
                 1L, "회사명", "http://career.com", "http://official.com", LocalDate.now(), "작성자",
-                10L, 5L, 100L, null, 10.0f
+                10L, 5L, 100L, null, 10.0
         );
         
         SliceCustom<TechArticleMainResponse> mockSlice = new SliceCustom<>(
@@ -130,7 +130,7 @@ class TechArticleControllerTest extends SupportControllerTest {
         TechArticleMainResponse response = createTechArticleMainResponse(
                 1L, "http://thumbnail.com", false, "http://article.com", "타이틀 1", "내용 1",
                 1L, "회사명", "http://career.com", "http://official.com", LocalDate.now(), "작성자",
-                10L, 5L, 100L, true, 10.0f
+                10L, 5L, 100L, true, 10.0
         );
         
         SliceCustom<TechArticleMainResponse> mockSlice = new SliceCustom<>(
@@ -512,7 +512,7 @@ class TechArticleControllerTest extends SupportControllerTest {
                                                                   String techArticleUrl, String title, String contents,
                                                                   Long companyId, String companyName, String careerUrl, String officialImageUrl,
                                                                   LocalDate regDate, String author, long recommendCount,
-                                                                  long commentCount, long viewCount, Boolean isBookmarked, Float score) {
+                                                                  long commentCount, long viewCount, Boolean isBookmarked, Double score) {
         return TechArticleMainResponse.builder()
                 .id(id)
                 .thumbnailUrl(thumbnailUrl)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/NotificationControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/NotificationControllerDocsTest.java
@@ -510,7 +510,7 @@ class NotificationControllerDocsTest extends SupportControllerDocsTest {
                                                                 String techArticleUrl, String title, String contents,
                                                                 Long companyId, String companyName, String careerUrl, String officialImageUrl,
                                                                 LocalDate regDate, String author, long recommendCount,
-                                                                long commentCount, long viewCount, Boolean isBookmarked, Float score) {
+                                                                long commentCount, long viewCount, Boolean isBookmarked, Double score) {
       return TechArticleMainResponse.builder()
               .id(id)
               .thumbnailUrl(thumbnailUrl)

--- a/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
+++ b/src/test/java/com/dreamypatisiel/devdevdev/web/docs/TechArticleControllerDocsTest.java
@@ -72,7 +72,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
         TechArticleMainResponse response = createTechArticleMainResponse(
                 1L, "http://thumbnail.com", false, "http://article.com", "타이틀 1", "내용 1",
                 1L, "회사명", "http://career.com", "http://official.com", LocalDate.now(), "작성자",
-                10L, 5L, 100L, true, 10.0f
+                10L, 5L, 100L, true, 10.0
         );
         
         SliceCustom<TechArticleMainResponse> mockSlice = new SliceCustom<>(
@@ -451,7 +451,7 @@ public class TechArticleControllerDocsTest extends SupportControllerDocsTest {
                                                                   String techArticleUrl, String title, String contents,
                                                                   Long companyId, String companyName, String careerUrl, String officialImageUrl,
                                                                   LocalDate regDate, String author, long recommendCount,
-                                                                  long commentCount, long viewCount, Boolean isBookmarked, Float score) {
+                                                                  long commentCount, long viewCount, Boolean isBookmarked, Double score) {
         return TechArticleMainResponse.builder()
                 .id(id)
                 .thumbnailUrl(thumbnailUrl)


### PR DESCRIPTION
## 📝 작업 내용

- 기술블로그 검색어 검색시 score 값 누락 및 정렬 조건에 오류 있던 부분 수정

## 🔗 참고할만한 자료(선택)

> 슬랙이나 피그마, Jira 등 참고 링크를 첨부해주세요

- [레포 이름 #이슈번호](이슈 주소)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
